### PR TITLE
Updates to divergence_map and divergence_stratigraphy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,4 +49,4 @@ RdMacros: Rdpack
 LinkingTo: Rcpp
 URL: https://github.com/HajkD/orthologr
 BugReports: https://github.com/HajkD/orthologr/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3

--- a/R/DivergenceMap.R
+++ b/R/DivergenceMap.R
@@ -6,7 +6,7 @@
 #' @param n_quantile a numeric value specifying the number of quantiles that should be returned.
 #' @details 
 #' 
-#' Divergence Strata are decile values of corresponding \code{\link{dNdS}} values.
+#' Divergence Strata are typically decile (10-quantile) values of corresponding \code{\link{dNdS}} values.
 #' The \code{\link{dNdS}} function returns dNdS values for orthologous genes
 #' of a query species (versus subject species). These dNdS values are then
 #' sorted into deciles and each orthologous protein coding gene of the
@@ -14,6 +14,8 @@
 #' 
 #' This allows a better comparison between Phylostrata and Divergence Strata (for more details see package: \pkg{myTAI}).
 #' 
+#' It is also possible to specify other number of quantile (N-quantile) value such as quintile (5-quantile) 
+#' rather than decile values.
 #' 
 #' @author Hajk-Georg Drost
 #' @examples \dontrun{
@@ -33,7 +35,12 @@
 #' 
 #' # in case you want the subject_id as well, you can set
 #' # the argument subject.id = TRUE
-#' divMap <- divergence_map( dNdS_tbl = dNdS_tbl, subject.id = TRUE)               
+#' divMap <- divergence_map( dNdS_tbl = dNdS_tbl, subject.id = TRUE)   
+#'             
+#'  # in case you want a divergence map with divergence stratum as quintile (5-quantile) values 
+#'  # or any other N-quantile values rather than the default decile (10-quantile) values,
+#'  # you can specify this with n_quantile.
+#' divMap <- divergence_map( dNdS_tbl = dNdS_tbl, subject.id = TRUE, n_quantile = 5) 
 #' 
 #' }
 #' @seealso \code{\link{divergence_stratigraphy}}

--- a/R/divergence_stratigraphy.R
+++ b/R/divergence_stratigraphy.R
@@ -136,6 +136,22 @@
 #'       quiet           = TRUE, 
 #'       clean_folders   = TRUE,
 #'       subject.id      = TRUE)
+#'  
+#'       
+#'       
+#'  # in case you want a divergence map with divergence stratum as quintile (5-quantile) values 
+#'  # or any other N-quantile values rather than the default decile (10-quantile) values,
+#'  # you can specify this with n_quantile.
+#'  divergence_stratigraphy(
+#'       query_file      = system.file('seqs/ortho_thal_cds.fasta', package = 'orthologr'),
+#'       subject_file    = system.file('seqs/ortho_lyra_cds.fasta', package = 'orthologr'),
+#'       eval            = "1E-5",
+#'       ortho_detection = "RBH", 
+#'       comp_cores      = 1, 
+#'       quiet           = TRUE, 
+#'       clean_folders   = TRUE,
+#'       n_quantile      = 5)
+#'       
 #'  }
 #'  
 #' @return A data.table storing the divergence map of the query organism.

--- a/R/divergence_stratigraphy.R
+++ b/R/divergence_stratigraphy.R
@@ -30,9 +30,10 @@
 #' @param quiet a logical value specifying whether a successful interface call shall be printed out to the console.
 #' @param clean_folders a logical value specifying whether the internal folder structure shall be deleted (cleaned) after
 #'  processing this function. Default is \code{clean_folders} = \code{FALSE}.
-#' @param ds.values a logical value specifying whether divegrence stratum values (ds values) or dNdS values shall be returned
+#' @param ds.values a logical value specifying whether divergence stratum values (ds values) or dNdS values shall be returned
 #' by \code{divergence_stratigraphy}. Default is \code{ds.values} = \code{TRUE}.
 #' @param subject.id a logical value indicating whether \code{query_id} AND \code{subject_id} should be returned.
+#' @param n_quantile a numeric value specifying the number of quantiles that should be returned.
 #' @details Introduced by Quint et al., 2012 and extended in Drost et al. 2015, divergence stratigraphy
 #'  is the process of quantifying the selection pressure (in terms of amino acid sequence divergence) acting on
 #'  orthologous genes between closely related species. The resulting sequence divergence map (short divergence map),
@@ -154,7 +155,8 @@ divergence_stratigraphy <- function(query_file,
                                     quiet           = FALSE, 
                                     clean_folders   = FALSE, 
                                     ds.values       = TRUE,
-                                    subject.id      = FALSE){
+                                    subject.id      = FALSE,
+                                    n_quantile      = 10){
         
         if (!is.ortho_detection_method(ortho_detection))
                 stop("Please choose a orthology detection method that is supported by this function.")
@@ -182,7 +184,7 @@ divergence_stratigraphy <- function(query_file,
         
         if (ds.values) {
                 # divergence map: standard = col1: divergence stratum, col2: query_id
-                dm_tbl <- divergence_map( dNdS_tbl = dNdS_tbl , subject.id = subject.id )
+                dm_tbl <- divergence_map( dNdS_tbl = dNdS_tbl , subject.id = subject.id , n_quantile = n_quantile)
         }
         
         if (!ds.values) {

--- a/man/divergence_map.Rd
+++ b/man/divergence_map.Rd
@@ -4,28 +4,33 @@
 \alias{divergence_map}
 \title{Sort dNdS Values Into Divergence Strata}
 \usage{
-divergence_map(dNdS_tbl, subject.id = FALSE)
+divergence_map(dNdS_tbl, subject.id = FALSE, n_quantile = 10)
 }
 \arguments{
 \item{dNdS_tbl}{a data.table object returned by \code{\link{dNdS}}.}
 
 \item{subject.id}{a logical value indicating whether \code{query_id} AND \code{subject_id} should be returned.}
+
+\item{n_quantile}{a numeric value specifying the number of quantiles that should be returned.}
 }
 \value{
 a data.table storing a standard divergence map.
 }
 \description{
 This function takes a data.table returned by dNdS
-and sorts the corresponding dNdS value into divergence strata (deciles).
+and sorts the corresponding dNdS value into divergence strata (10-quantile or deciles by default).
 }
 \details{
-Divergence Strata are decile values of corresponding \code{\link{dNdS}} values.
+Divergence Strata are typically decile (10-quantile) values of corresponding \code{\link{dNdS}} values.
 The \code{\link{dNdS}} function returns dNdS values for orthologous genes
 of a query species (versus subject species). These dNdS values are then
 sorted into deciles and each orthologous protein coding gene of the
 query species receives a corresponding decile value instead of the initial dNdS value.
 
 This allows a better comparison between Phylostrata and Divergence Strata (for more details see package: \pkg{myTAI}).
+
+It is also possible to specify other number of quantile (N-quantile) value such as quintile (5-quantile) 
+rather than decile values.
 }
 \examples{
 \dontrun{
@@ -45,7 +50,12 @@ divMap <- divergence_map( dNdS_tbl )
 
 # in case you want the subject_id as well, you can set
 # the argument subject.id = TRUE
-divMap <- divergence_map( dNdS_tbl = dNdS_tbl, subject.id = TRUE)               
+divMap <- divergence_map( dNdS_tbl = dNdS_tbl, subject.id = TRUE)   
+            
+ # in case you want a divergence map with divergence stratum as quintile (5-quantile) values 
+ # or any other N-quantile values rather than the default decile (10-quantile) values,
+ # you can specify this with n_quantile.
+divMap <- divergence_map( dNdS_tbl = dNdS_tbl, subject.id = TRUE, n_quantile = 5) 
 
 }
 }

--- a/man/divergence_stratigraphy.Rd
+++ b/man/divergence_stratigraphy.Rd
@@ -18,7 +18,8 @@ divergence_stratigraphy(
   quiet = FALSE,
   clean_folders = FALSE,
   ds.values = TRUE,
-  subject.id = FALSE
+  subject.id = FALSE,
+  n_quantile = 10
 )
 }
 \arguments{
@@ -62,10 +63,12 @@ Hence all genes having a dNdS value <= \code{dnds.threshold} are retained. Defau
 \item{clean_folders}{a logical value specifying whether the internal folder structure shall be deleted (cleaned) after
 processing this function. Default is \code{clean_folders} = \code{FALSE}.}
 
-\item{ds.values}{a logical value specifying whether divegrence stratum values (ds values) or dNdS values shall be returned
+\item{ds.values}{a logical value specifying whether divergence stratum values (ds values) or dNdS values shall be returned
 by \code{divergence_stratigraphy}. Default is \code{ds.values} = \code{TRUE}.}
 
 \item{subject.id}{a logical value indicating whether \code{query_id} AND \code{subject_id} should be returned.}
+
+\item{n_quantile}{a numeric value specifying the number of quantiles that should be returned.}
 }
 \value{
 A data.table storing the divergence map of the query organism.
@@ -174,6 +177,22 @@ on an 8 core machine can take up to 1,5 - 2 hours.
       quiet           = TRUE, 
       clean_folders   = TRUE,
       subject.id      = TRUE)
+ 
+      
+      
+ # in case you want a divergence map with divergence stratum as quintile (5-quantile) values 
+ # or any other N-quantile values rather than the default decile (10-quantile) values,
+ # you can specify this with n_quantile.
+ divergence_stratigraphy(
+      query_file      = system.file('seqs/ortho_thal_cds.fasta', package = 'orthologr'),
+      subject_file    = system.file('seqs/ortho_lyra_cds.fasta', package = 'orthologr'),
+      eval            = "1E-5",
+      ortho_detection = "RBH", 
+      comp_cores      = 1, 
+      quiet           = TRUE, 
+      clean_folders   = TRUE,
+      n_quantile      = 5)
+      
  }
  
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // Different
 bool Different(const std::string& seq1, const std::string& seq2, bool skip_missing, bool nucleic_acid);
 RcppExport SEXP _orthologr_Different(SEXP seq1SEXP, SEXP seq2SEXP, SEXP skip_missingSEXP, SEXP nucleic_acidSEXP) {

--- a/vignettes/divergence_stratigraphy.Rmd
+++ b/vignettes/divergence_stratigraphy.Rmd
@@ -81,20 +81,14 @@ The CDS retrieval can be done using a `Terminal` or by manual downloading the fi
 ```shell
 
 # download CDS file of A. thaliana
-curl ftp://ftp.ensemblgenomes.org/pub/
-plants/release-23/fasta/arabidopsis_thaliana/
-cds/Arabidopsis_thaliana.TAIR10.23.cds.all.fa.gz 
--o Arabidopsis_thaliana.TAIR10.23.cds.all.fa.gz
+curl ftp://ftp.ensemblgenomes.org/pub/plants/release-23/fasta/arabidopsis_thaliana/cds/Arabidopsis_thaliana.TAIR10.23.cds.all.fa.gz -o Arabidopsis_thaliana.TAIR10.23.cds.all.fa.gz
 
 # unzip the fasta file
 gunzip -d Arabidopsis_thaliana.TAIR10.23.cds.all.fa.gz
 
 # download CDS file of A. lyrata
 
-curl ftp://ftp.ensemblgenomes.org/pub/plants/
-release-23/fasta/arabidopsis_lyrata/cds/
-Arabidopsis_lyrata.v.1.0.23.cds.all.fa.gz 
--o Arabidopsis_lyrata.v.1.0.23.cds.all.fa.gz
+curl ftp://ftp.ensemblgenomes.org/pub/plants/release-23/fasta/arabidopsis_lyrata/cds/Arabidopsis_lyrata.v.1.0.23.cds.all.fa.gz -o Arabidopsis_lyrata.v.1.0.23.cds.all.fa.gz
 
 # unzip the fasta file
 gunzip -d Arabidopsis_lyrata.v.1.0.23.cds.all.fa.gz


### PR DESCRIPTION
When deciling the dNdS values for closely related organisms with `dNdS = 0` for over 10% of the genes, I noticed that some divergence strata were empty.

For example, we have Fd_DM, which is the output of divergence_stratigraphy()
```
> table(Fd_DM$DS)
 
   3    4    5    6    7    8    9   10 
 785  784  784  786  784  785  785 2355
```
I have added an error message when two elements in the `QuantileValue` vector in `divergence_map()` are duplicated. To also overcome this issue, I introduced an additional option for the `divergence_map()` and `divergence_stratigraphy()`, `n_quantile` (default = 10), for users to specify the quantile number other than decile (10-quantile). By specifying a lower quantile number, cases where (dNdS == 0) > 10% can be accounted for. Example use for `n_quantile` has been documented.

The potential biological issues with calculating the divergence_stratigraphy and the downstream TDI analysis using two very closely related species (with `dNdS = 0` for over 10% of the genes) remain unaddressed.