### PR TITLE
Minor changes to remove three warnings when running devtools::check()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@ docs
 LICENSE
 orthologr-conda-env.sh
 orthologr.yml
+^orthologr-conda-env\.sh$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,16 +37,19 @@ Imports:
     ape,
     ggplot2,
     scales,
-    Rdpack
+    Rdpack,
+    R.utils,
+    benchmarkme
 Suggests:
     knitr (>= 1.6),
     rmarkdown (>= 0.3.3),
     devtools (>= 1.6.1),
-    testthat (>= 0.9.1),
-    benchmarkme
+    testthat (>= 3.0.0)
 Remotes: HajkD/metablastr
 RdMacros: Rdpack
 LinkingTo: Rcpp
 URL: https://github.com/HajkD/orthologr
 BugReports: https://github.com/HajkD/orthologr/issues
 RoxygenNote: 7.2.3
+Config/testthat/edition: 3
+Encoding: UTF-8

--- a/R/check_annotation.R
+++ b/R/check_annotation.R
@@ -25,7 +25,7 @@ check_annotation <- function(annotation_file, remove_annotation_outliers = FALSE
         if (!file.exists(annotation_file))
                 stop("The file '", annotation_file, "' does not seem to exist. Please provide a valid path to the annotation file.", call. = FALSE)
         
-        if (suppressWarnings(require("benchmarkme"))) {
+        if (suppressWarnings(requireNamespace("benchmarkme"))) {
                 ram <- check_ram()
                 available_ram <- ram - ((ram / 100) * 20)
                 annotation_file_size <-

--- a/R/orthofinder2.R
+++ b/R/orthofinder2.R
@@ -13,9 +13,9 @@
 #' \item \code{import_type = ""}
 #' }
 #' @param comp_cores number of cores that shall be used for parallel processing. Default is \code{cores = 1}.
-#' @param path a character string specifying the path to the locally installed \code{orthofinder} executable.
-#' A possible specification could be \code{path = "/opt/miniconda3/bin/"} which internally will translate to
-#' \code{/opt/miniconda3/bin/orthofinder}. The default is \code{path = NULL} which means that orthofinder assumes
+#' @param of_path a character string specifying the path to the locally installed \code{orthofinder} executable.
+#' A possible specification could be \code{of_path = "/opt/miniconda3/bin/"} which internally will translate to
+#' \code{/opt/miniconda3/bin/orthofinder}. The default is \code{of_path = NULL} which means that orthofinder assumes
 #' users have their \code{orthofinder} executable stored at \code{/opt/miniconda3/bin/orthofinder}.
 #' @author Hajk-Georg Drost
 #' @note This function assumes that users have \code{OrthoFinder} installed via \code{miniconda} and stored at \code{~/opt/miniconda3/bin/}.

--- a/man/orthofinder2.Rd
+++ b/man/orthofinder2.Rd
@@ -30,9 +30,9 @@ Options are:
 
 \item{comp_cores}{number of cores that shall be used for parallel processing. Default is \code{cores = 1}.}
 
-\item{path}{a character string specifying the path to the locally installed \code{orthofinder} executable.
-A possible specification could be \code{path = "/opt/miniconda3/bin/"} which internally will translate to
-\code{/opt/miniconda3/bin/orthofinder}. The default is \code{path = NULL} which means that orthofinder assumes
+\item{of_path}{a character string specifying the path to the locally installed \code{orthofinder} executable.
+A possible specification could be \code{of_path = "/opt/miniconda3/bin/"} which internally will translate to
+\code{/opt/miniconda3/bin/orthofinder}. The default is \code{of_path = NULL} which means that orthofinder assumes
 users have their \code{orthofinder} executable stored at \code{/opt/miniconda3/bin/orthofinder}.}
 }
 \description{

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,3 +1,11 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/tests.html
+# * https://testthat.r-lib.org/reference/test_package.html#special-files
+
 library(testthat)
 library(orthologr)
 


### PR DESCRIPTION
`devtools::check()` led to warnings. To fix this, I replaced `require` with `requireNamespace` (`require` is not recommended https://stackoverflow.com/questions/15648772/how-do-i-prevent-r-library-or-require-calls-not-declared-warnings-when-dev), parameter `path` with `of_path` in the description of `R/orthofinder2.R` (as it was an inconsistency) and ignoring `orthologr-conda-env.sh`. I also added `Encoding: UTF-8` to `DESCRIPTION` (see https://stackoverflow.com/questions/51694929/warning-about-utf-8-with-roxygen2).