### PR TITLE
Update documentation and dependency management

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,10 +26,7 @@ Imports:
     Rcpp (>= 0.11.3),
     Biostrings (>= 2.52.0),
     pwalign (>= 1.6.0),
-    RSQLite (>= 0.11.4),
     stringr (>= 0.6.2),
-    IRanges,
-    DBI (>= 0.3.1),
     dtplyr,
     rtracklayer,
     tibble,
@@ -42,6 +39,9 @@ Imports:
     benchmarkme
 Suggests:
     knitr (>= 1.6),
+    DBI (>= 0.3.1),
+    IRanges,
+    RSQLite (>= 0.11.4),
     rmarkdown (>= 0.3.3),
     devtools (>= 1.6.1),
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,13 +2,12 @@ Package: orthologr
 Type: Package
 Title: Comparative Genomics with R
 Version: 0.4.2
-Date: 2023-09-08
+Date: 2026-06-02
 Authors@R: c(
             person("Hajk-Georg", "Drost", , "hajk-georg.drost@tuebingen.mpg.de", c("aut", "cre")),
             person("Sarah", "Scharfenberg", , "Sarah.Scharfenberg@ipb-halle.de", role = "ctb"),
             person("Jaruwatana Sodai", "Lotharukpong", , "jaruwatana.lotharukpong@tuebingen.mpg.de", role = "ctb", comment = c(ORCID = "0000-0002-3475-0980"))
             )
-Maintainer: Hajk-Georg Drost <hajk-georg.drost@tuebingen.mpg.de>
 Description: Genome-wide orthology inference and dN/dS estimation between multiple genomes. 
 License: GPL-2
 SystemRequirements: C++11, Perl
@@ -19,7 +18,6 @@ Depends:
     data.table (>= 1.9.4)
 Imports:
     seqinr,
-    metablastr,
     fs,
     parallel (>= 3.0.2),
     dplyr (>= 0.3.0.2),
@@ -46,12 +44,12 @@ Suggests:
     knitr (>= 1.6),
     rmarkdown (>= 0.3.3),
     devtools (>= 1.6.1),
-    testthat (>= 3.0.0)
-Remotes: HajkD/metablastr
+    testthat (>= 3.0.0),
+    metablastr
 RdMacros: Rdpack
 LinkingTo: Rcpp
 URL: https://github.com/drostlab/orthologr
 BugReports: https://github.com/drostlab/orthologr/issues
-RoxygenNote: 7.2.3
 Config/testthat/edition: 3
 Encoding: UTF-8
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -71,13 +71,13 @@ which now allows users to select different dNdS estimation methods when running 
 
 ### Removed Functions
 
-- the function `advanced_blast()` is not supported anymore and thus is not available to users anymore (please consult the [metablastr package](https://github.com/HajkD/metablastr) in case you need this functionality)
+- the function `advanced_blast()` is not supported anymore and thus is not available to users anymore (please consult the [metablastr package](https://github.com/drostlab/metablastr) in case you need this functionality)
 
-- the function `advanced_makedb()` is not supported anymore and thus is not available to users anymore (please consult the [metablastr package](https://github.com/HajkD/metablastr) in case you need this functionality)
+- the function `advanced_makedb()` is not supported anymore and thus is not available to users anymore (please consult the [metablastr package](https://github.com/drostlab/metablastr) in case you need this functionality)
 
-- the function `blast.nr()` is not supported anymore and thus is not available to users anymore (please consult the [metablastr package](https://github.com/HajkD/metablastr) in case you need this functionality)
+- the function `blast.nr()` is not supported anymore and thus is not available to users anymore (please consult the [metablastr package](https://github.com/drostlab/metablastr) in case you need this functionality)
 
-- the function `delta.blast()` is not supported anymore and thus is not available to users anymore (please consult the [metablastr package](https://github.com/HajkD/metablastr) in case you need this functionality)
+- the function `delta.blast()` is not supported anymore and thus is not available to users anymore (please consult the [metablastr package](https://github.com/drostlab/metablastr) in case you need this functionality)
 
 - the function `ProteinOrtho()` is not supported anymore and thus is not available to users anymore
 
@@ -106,7 +106,7 @@ Thus, given the new trimming feature in `read.cds()`, corrupted CDS equences wil
 ### Bug fixes
 
 - The default setting of the `BLAST` argument `max_target_seqs 1` was removed from `blast_best()` and `blast_rec()` due to
-the misunderstood functionality of the `BLAST` argument (See details [here](https://watermark.silverchair.com/bty833.pdf?token=AQECAHi208BE49Ooan9kkhW_Ercy7Dm3ZL_9Cf3qfKAc485ysgAAAokwggKFBgkqhkiG9w0BBwagggJ2MIICcgIBADCCAmsGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMvrRsd_dqJkkrO5AiAgEQgIICPNCvHwDI6PCzjXjP4FtOO2O0HPaNbVmBBOW7I0YBwK6an33k32Zm3d24U1pB5TsoPAmqK1TBBz8y9IEEynMl7IQKmupg3MXTiUqUe0oLrMDIrL4Szunm255RdiIlvq5RDR5V3B7ejVCxTbwbmvbggBHyiMCcvEEufaNROT8z7XXaUiHx3OyD1HaRkXIM4MC5x_b734rkKFIploMWjLSX5KZS1i2prd_Shn2seyV4E2cj3RVw9YzcBEZvRHpbhzWIOWSjXR3ZqYTlDCxzk5CO0d15J57u3C64sM1rQRo2Atny5KR5VL4oLxy8bBBGsQl-k6lQavisoshkBZPfLMr5kEHMrCmCtw2Q2A6pzgYC-jJ7udunpA7DK2GZsSQc-ApYXHFdEOovrtFYNHFrqlE8IsooVB7U89re0lMzZM4gYoMzcDuvLFQ1_msIl51QMmPi8yIY6E5DA2h1Ho93wUxekwTBdxB3ovAtpz4_J93w8cn4z2EK9ygHoxLRQ90kfd7nawSMTxFwBxDB0iK3_w0YtnObzcyd_JAWZM9fobNHDc1CY9j4DWKclIxhqHeCHKMtw9nB9CSa7Bccbf1EBHw4uf1-qYl30IdUsKQUpP5YOtKA7nUDTpTJiKKEf1V3MmW6rPreBayi45-QPk7GkhlrgJgaXdU4LMSGxjaDdcXhOX3W35Y95VSAZEf3rlueplgDTRnRxu8NNZ8S1c5ccA1vP0gFth80NTwzUzZy2kSITIndok_0MWSeuavaRQ7g) and #9 ; Many thanks to @armish)
+the misunderstood functionality of the `BLAST` argument (See details [here](https://doi.org/10.1093/bioinformatics/bty833) and #9 ; Many thanks to @armish)
 
 ## `orthologr` version  0.0.4
 
@@ -135,9 +135,9 @@ stores all corrupted CDS so that they can be investigated. See issue #8 for deta
 
 ## `orthologr` version  0.0.3
 
-- Fixing internal path bug that caused that wrong pal2nal paths were generated when using multiple sequence aligners -> see issue https://github.com/HajkD/orthologr/issues/5 (Many thanks to Dr. Mario López-Pérez)
+- Fixing internal path bug that caused that wrong pal2nal paths were generated when using multiple sequence aligners -> see issue https://github.com/drostlab/orthologr/issues/5 (Many thanks to Dr. Mario López-Pérez)
 
 ## `orthologr` version  0.0.2
 
 - Fixing a major bug that caused KaKs_Calculator to not be able to correctly 
-parse the kaks computation output (Many thanks to [Hongyi Li](https://github.com/lihongyi123) who spotted the bug and found a solution).
+parse the kaks computation output (Many thanks to Hongyi Li who spotted the bug and found a solution).

--- a/R/blast.R
+++ b/R/blast.R
@@ -62,9 +62,9 @@
 #'
 #' Camacho C., Coulouris G., Avagyan V., Ma N., Papadopoulos J., Bealer K., & Madden T.L. (2008) "BLAST+: architecture and applications." BMC Bioinformatics 10:421.
 #'
-#' http://www.ncbi.nlm.nih.gov/books/NBK1763/table/CmdLineAppsManual.T.options_common_to_al/?report=objectonly
+#' https://www.ncbi.nlm.nih.gov/books/NBK1763/table/CmdLineAppsManual.T.options_common_to_al/?report=objectonly
 #'
-#' http://blast.ncbi.nlm.nih.gov/Blast.cgi
+#' https://blast.ncbi.nlm.nih.gov/Blast.cgi
 #' @examples \dontrun{
 #' # performing a BLAST search using blastp (default)
 #' blast(query_file   = system.file('seqs/ortho_thal_cds.fasta', package = 'orthologr'),
@@ -356,7 +356,7 @@ blast <- function(query_file,
         })
         
         # additional blast parameters can be found here:
-        # http://www.ncbi.nlm.nih.gov/books/NBK1763/table/CmdLineAppsManual.T.options_common_to_al/?report=objectonly
+        # https://www.ncbi.nlm.nih.gov/books/NBK1763/table/CmdLineAppsManual.T.options_common_to_al/?report=objectonly
         blast_table_names <-
                 c(
                         "query_id",

--- a/R/codon_aln.R
+++ b/R/codon_aln.R
@@ -61,11 +61,9 @@
 #' Mikita Suyama, David Torrents, and Peer Bork (2006)
 #' PAL2NAL: robust conversion of protein sequence alignments into the corresponding codon alignments. Nucleic Acids Res. 34, W609-W612.
 #' 
-#' http://www.bork.embl.de/pal2nal/
+#' https://www.bork.embl.de/services.html
 #' 
-#' http://www.genome.med.kyoto-u.ac.jp/cgi-bin/suyama/pal2nal/index.cgi
-#' 
-#' http://abacus.gene.ucl.ac.uk/software/paml.html
+#' https://github.com/abacus-gene/paml/wiki
 #' 
 #' @seealso \code{\link{pairwise_aln}}, \code{\link{multi_aln}}, \code{\link{substitutionrate}},
 #'  \code{\link{dNdS}}, \code{\link{divergence_stratigraphy}}

--- a/R/compute_dnds.R
+++ b/R/compute_dnds.R
@@ -41,7 +41,7 @@
 #' 
 #' 3) dNdS estimation of the codon alignment returned by 2)
 #' 
-#' @references \url{http://www.r-bloggers.com/the-wonders-of-foreach/}
+#' @references \url{https://www.r-bloggers.com/2013/08/the-wonders-of-foreach/}
 #' @seealso \code{\link{multi_aln}}, \code{\link{substitutionrate}}, \code{\link{dNdS}}
 #' @import foreach 
 #' @import data.table

--- a/R/compute_dnds.R
+++ b/R/compute_dnds.R
@@ -154,9 +154,9 @@ compute_dnds <- function(complete_tbl,
                                 #multi_aln_tool_params <- paste0(aa_aln_tool,".",params)
                                 
                                 
-                                #                 pairwise_aln <- Biostrings::pairwiseAlignment(aa_seqs[[1]],aa_seqs[[2]], type = "global")
+                                #                 pairwise_aln <- pwalign::pairwiseAlignment(aa_seqs[[1]],aa_seqs[[2]], type = "global")
                                 #
-                                #                 Biostrings::writePairwiseAlignments(pairwise_aln, block.width = 60)
+                                #                 pwalign::writePairwiseAlignments(pairwise_aln, block.width = 60)
                                 #
                                 
                                 if (aa_aln_type == "multiple") {
@@ -321,9 +321,9 @@ compute_dnds <- function(complete_tbl,
                                 # which multi_aln tool should get the parameters
                                 #multi_aln_tool_params <- paste0(aa_aln_tool,".",params)
                                 
-                                #                 pairwise_aln <- Biostrings::pairwiseAlignment(aa_seqs[[1]],aa_seqs[[2]], type = "global")
+                                #                 pairwise_aln <- pwalign::pairwiseAlignment(aa_seqs[[1]],aa_seqs[[2]], type = "global")
                                 #
-                                #                 Biostrings::writePairwiseAlignments(pairwise_aln, block.width = 60)
+                                #                 pwalign::writePairwiseAlignments(pairwise_aln, block.width = 60)
                                 #
                                 
                                 if (aa_aln_type == "multiple") {

--- a/R/dNdS.R
+++ b/R/dNdS.R
@@ -143,17 +143,17 @@
 #' 
 #' @references
 #' 
-#' seqinr: \url{http://seqinr.r-forge.r-project.org/}
+#' seqinr: \url{https://cran.r-project.org/package=seqinr}
 #' 
 #' Zhang Z, Li J, Zhao XQ, Wang J, Wong GK, Yu J: KaKs Calculator: Calculating Ka and Ks through model selection and model averaging. Genomics Proteomics Bioinformatics 2006 , 4:259-263. 
 #' 
-#' KaKs_Calculator: \url{https://code.google.com/p/kaks-calculator/} [GNU GPL-3 license]
+#' KaKs_Calculator: \url{https://code.google.com/archive/p/kaks-calculator} [GNU GPL-3 license]
 #' 
 #' Paradis, E. (2012) Analysis of Phylogenetics and Evolution with R (Second Edition). New York: Springer.
 #'
 #' Paradis, E., Claude, J. and Strimmer, K. (2004) APE: analyses of phylogenetics and evolution in R language. Bioinformatics, 20, 289-290.
 #' 
-#' More information on \pkg{ape} can be found at \url{http://ape-package.ird.fr/}.
+#' More information on \pkg{ape} can be found at \url{https://emmanuelparadis.github.io/} or \url{https://github.com/emmanuelparadis/ape}.
 #' 
 #' Pages H, Aboyoun P, Gentleman R and DebRoy S. Biostrings: String objects representing biological sequences, and
 #' matching algorithms. R package version 2.32.1.

--- a/R/io.R
+++ b/R/io.R
@@ -8,7 +8,7 @@
 #' of interest as first argument.
 #'
 #' It is possible to read in different genome file standards such as \emph{fasta} or \emph{fastq}.
-#' Genomes stored in fasta files can be downloaded from http://ensemblgenomes.org/info/genomes.
+#' Genomes stored in fasta files can be downloaded from https://ensemblgenomes.org, https://www.ncbi.nlm.nih.gov/genome, or https://www.ebi.ac.uk, etc.
 #'
 #' @examples \dontrun{
 #' # reading a genome stored in a fasta file
@@ -65,7 +65,7 @@ read.genome <- function(file, format, ...){
 #'
 #' It is possible to read in different proteome file standards such as \emph{fasta} or \emph{fastq}.
 #'
-#' Proteomes stored in fasta files can be downloaded from http://www.ebi.ac.uk/reference_proteomes.
+#' Proteomes stored in fasta files can be downloaded from https://www.ebi.ac.uk/reference_proteomes, etc.
 #'
 #' @examples \dontrun{
 #' # reading a proteome stored in a fasta file
@@ -121,7 +121,7 @@ read.proteome <- function(file, format, ...){
 #'
 #' It is possible to read in different proteome file standards such as \emph{fasta} or \emph{fastq}.
 #'
-#' CDS stored in fasta files can be downloaded from http://www.ensembl.org/info/data/ftp/index.html.
+#' CDS stored in fasta files can be downloaded from https://www.ensembl.org/info/data/ftp/index.html, etc.
 #'
 #' @examples \dontrun{
 #' # reading a cds file stored in fasta format

--- a/R/multi_aln.R
+++ b/R/multi_aln.R
@@ -143,7 +143,7 @@
 #'           path    = "path/to/t_coffee/")
 #' 
 #' # running t_coffee using additional parameters
-#' # details: http://www.tcoffee.org/Projects/tcoffee/#DOCUMENTATION
+#' # details: https://tcoffee.readthedocs.io/en/latest/tcoffee_technical_documentation.html
 #' multi_aln(file    = system.file('seqs/aa_seqs.fasta', package = 'orthologr'),
 #'           tool    = "t_coffee", 
 #'           get_aln = TRUE,
@@ -165,7 +165,7 @@
 #'           path    = "path/to/muscle/")
 #' 
 #' # running muscle using additional parameters
-#' # details: http://www.drive5.com/muscle/manual/
+#' # details: https://www.drive5.com/muscle/manual/
 #' multi_aln(file    = system.file('seqs/aa_seqs.fasta', package = 'orthologr'),
 #'           tool    = "muscle", 
 #'           get_aln = TRUE,
@@ -207,7 +207,7 @@
 #'           path    = "path/to/mafft/")
 #' 
 #' # running mafft using additional parameters
-#' # details: http://www.drive5.com/mafft/manual/
+#' # details: https://mafft.cbrc.jp/alignment/software/manual/manual.html
 #' multi_aln(file    = system.file('seqs/aa_seqs.fasta', package = 'orthologr'),
 #'           tool    = "mafft", 
 #'           get_aln = TRUE,
@@ -224,9 +224,9 @@
 #' Wallace IM, Wilm A, Lopez R, Thompson JD, Gibson TJ, Higgins DG. (2007).
 #' Clustal W and Clustal X version 2.0. Bioinformatics, 23, 2947-2948.
 #' 
-#' \url{http://www.clustal.org/clustal2/}
+#' \url{https://www.clustal.org/clustal2/}
 #' 
-#' \url{http://www.ebi.ac.uk/Tools/msa/clustalw2/help/}
+#' \url{https://www.ebi.ac.uk/jdispatcher/}
 #' 
 #' 
 #' \item T_COFFEE
@@ -234,9 +234,9 @@
 #' T-Coffee: A novel method for multiple sequence alignments. 
 #' Notredame, Higgins, Heringa, JMB, 302(205-217). 2000.
 #' 
-#' \url{http://www.tcoffee.org/Projects/tcoffee/}
+#' \url{https://tcoffee.readthedocs.io/en/latest//}
 #' 
-#' \url{http://www.tcoffee.org/Projects/tcoffee/documentation/t_coffee_tutorial.pdf}
+#' \url{https://tcoffee.readthedocs.io/en/latest/tcoffee_technical_documentation.html}
 #' 
 #' 
 #' \item MUSCLE:
@@ -245,9 +245,9 @@
 #' 
 #' Edgar, R.C. (2004) MUSCLE: a multiple sequence alignment method with reduced time and space complexity. BMC Bioinformatics, (5) 113. 
 #' 
-#' \url{http://www.drive5.com/muscle/}
+#' \url{https://www.drive5.com/muscle/}
 #' 
-#' \url{http://www.drive5.com/muscle/manual/}
+#' \url{https://www.drive5.com/muscle/manual/}
 #' 
 #' 
 #' \item CLUSTALO:
@@ -255,20 +255,20 @@
 #' Sievers F, Wilm A, Dineen DG, Gibson TJ, Karplus K, Li W, Lopez R, McWilliam H, Remmert M, Soeding J, Thompson JD, Higgins DG (2011). 
 #' Fast, scalable generation of high-quality protein multiple sequence alignments using Clustal Omega. Molecular Systems Biology 7:539 doi:10.1038/msb.2011.75
 #' 
-#' \url{http://www.clustal.org/omega/}
+#' \url{https://www.ebi.ac.uk/jdispatcher/msa/clustalo/}
 #' 
-#' \url{http://www.clustal.org/omega/README}
+#' \url{https://www.genome.jp/tools-bin/clustalw}
 #' 
 #' \item MAFFT : 
 #' 
 #' Katoh, Standley 2013 (Molecular Biology and Evolution 30:772-780)  
 #' MAFFT multiple sequence alignment software version 7: improvements in performance and usability. 
 #' 
-#' \url{http://mafft.cbrc.jp/alignment/software/}
+#' \url{https://mafft.cbrc.jp/alignment/software/}
 #' 
-#' \url{http://mafft.cbrc.jp/alignment/software/manual/manual.html}
+#' \url{https://mafft.cbrc.jp/alignment/software/manual/manual.html}
 #' 
-#' \url{http://mafft.cbrc.jp/alignment/software/tips0.html}
+#' \url{https://mafft.cbrc.jp/alignment/software/tips0.html}
 #' 
 #' }
 #' @return In case the argument \code{get_aln} is set \code{TRUE}, an object of class alignment of the seqinr package is returned.
@@ -462,7 +462,7 @@ multi_aln <- function(file,
                                         
                                         # use the default parameters when running t_coffee
                                         # perform an accurate alignment which is very accurate, but slow
-                                        # http://www.tcoffee.org/Projects/tcoffee/#DOCUMENTATION
+                                        # https://tcoffee.readthedocs.io/en/latest/tcoffee_technical_documentation.html
                                         system(
                                                 paste0(
                                                         "t_coffee -infile ",
@@ -490,7 +490,7 @@ multi_aln <- function(file,
                                 if (is.null(params)) {
                                         # use the default parameters when running t_coffee
                                         # perform a accurate alignment which is very accurate, but slow
-                                        # http://www.tcoffee.org/Projects/tcoffee/#DOCUMENTATION
+                                        # https://tcoffee.readthedocs.io/en/latest/tcoffee_technical_documentation.html
                                         system(
                                                 paste0(
                                                         "export PATH=$PATH:",
@@ -798,7 +798,7 @@ multi_aln <- function(file,
                                         
                                         # To avoid error with pal2nal when deleting * during multiple
                                         # alignment add --anysymbol
-                                        # http://mbe.oxfordjournals.org/content/early/2013/02/08/molbev.mst010.full
+                                        # https://academic.oup.com/mbe/content/early/2013/02/08/molbev.mst010.full
                                         
                                 } else {
                                         # add additional parameters when running mafft

--- a/R/multi_aln.R
+++ b/R/multi_aln.R
@@ -234,7 +234,7 @@
 #' T-Coffee: A novel method for multiple sequence alignments. 
 #' Notredame, Higgins, Heringa, JMB, 302(205-217). 2000.
 #' 
-#' \url{https://tcoffee.readthedocs.io/en/latest//}
+#' \url{https://tcoffee.readthedocs.io/en/latest/}
 #' 
 #' \url{https://tcoffee.readthedocs.io/en/latest/tcoffee_technical_documentation.html}
 #' 

--- a/R/orthologs.lnc.R
+++ b/R/orthologs.lnc.R
@@ -44,7 +44,7 @@
 #' in the second column and the amino acid sequences in the third column.
 #' @references
 #' 
-#' BLAST: http://blast.ncbi.nlm.nih.gov/blastcgihelp.shtml
+#' BLAST: https://blast.ncbi.nlm.nih.gov/blastcgihelp.shtml
 #' 
 #' ProteinOrtho: https://www.bioinf.uni-leipzig.de/Software/proteinortho/
 #'

--- a/R/orthologs_lnc.R
+++ b/R/orthologs_lnc.R
@@ -44,7 +44,7 @@
 #' in the second column and the amino acid sequences in the third column.
 #' @references
 #' 
-#' BLAST: http://blast.ncbi.nlm.nih.gov/blastcgihelp.shtml
+#' BLAST: https://blast.ncbi.nlm.nih.gov/blastcgihelp.shtml
 #' 
 #' ProteinOrtho: https://www.bioinf.uni-leipzig.de/Software/proteinortho/
 #'
@@ -99,6 +99,10 @@ orthologs_lnc <- function(query_file,
                 if (length(subject_file) > 1)
                         stop("The BLAST best hit method is only defined for pairwise comparisons.", call. = FALSE)
                 
+                if (!requireNamespace("metablastr", quietly = TRUE))
+                        stop("Package 'metablastr' is required for lncRNA orthology inference but is not installed. ",
+                             "Install it with: remotes::install_github('drostlab/metablastr')", call. = FALSE)
+                
                 ortho_tbl <- metablastr::blast_best_hit(
                         query      = query_file,
                         subject =  subject_file,
@@ -117,6 +121,10 @@ orthologs_lnc <- function(query_file,
                 
                 if (length(subject_file) > 1)
                         stop("The BLAST best reciprocal hit method is only defined for pairwise comparisons.", call. = FALSE)
+                
+                if (!requireNamespace("metablastr", quietly = TRUE))
+                        stop("Package 'metablastr' is required for lncRNA orthology inference but is not installed. ",
+                             "Install it with: remotes::install_github('drostlab/metablastr')", call. = FALSE)
                 
                 ortho_tbl <- metablastr::blast_best_reciprocal_hit(
                         query      = query_file,

--- a/R/promotor_divergence_estimation.R
+++ b/R/promotor_divergence_estimation.R
@@ -49,7 +49,7 @@ promotor_divergence_estimation <-
                 
                 # compute global pairwise alignments between query and subject promotor sequences
                 Alignments <-
-                        Biostrings::pairwiseAlignment(query_seqs, subject_seqs)
+                        pwalign::pairwiseAlignment(query_seqs, subject_seqs)
                 
                 names_query_seqs <- names(query_seqs)
                 names_subject_seqs <- names(subject_seqs)

--- a/R/substitutionrate.R
+++ b/R/substitutionrate.R
@@ -105,9 +105,7 @@
 #' Zhang Z, Li J, Zhao XQ, Wang J, Wong GK, Yu J: KaKs Calculator:
 #' Calculating Ka and Ks through model selection and model averaging. Genomics Proteomics Bioinformatics 2006 , 4:259-263.
 #' 
-#' https://code.google.com/p/kaks-calculator/wiki/KaKs_Calculator
-#' 
-#' https://code.google.com/p/kaks-calculator/wiki/AXT
+#' https://code.google.com/archive/p/kaks-calculator
 #' 
 #' @return A data.table storing the query_id, subject_id, dN, dS, and dNdS values or 
 #' a data.table storing the query_id, method, dN, dS, and dNdS values when using KaKs_Calculator.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can find a detailed list of all `orthologr` functions here: https://drostlab
 **Please cite the following paper in which I introduce `orthologr` when using this package for your own research. This will allow me to continue
 working on this software tool and will motivate me to extend its functionality and usability in the next years. Many thanks in advance :)**
 
-> Drost et al. 2015. __Evidence for Active Maintenance of Phylotranscriptomic Hourglass Patterns in Animal and Plant Embryogenesis__. _Mol. Biol. Evol._ 32 (5): 1221-1231. [doi:10.1093/molbev/msv012](http://mbe.oxfordjournals.org/content/32/5/1221.abstract?sid=767aea12-1eb3-40be-8c6a-e2861f159b46)
+> Drost et al. 2015. __Evidence for Active Maintenance of Phylotranscriptomic Hourglass Patterns in Animal and Plant Embryogenesis__. _Mol. Biol. Evol._ 32 (5): 1221-1231. [doi:10.1093/molbev/msv012](https://doi.org/10.1093/molbev/msv012)
 
 ### Short package description
 
@@ -153,7 +153,7 @@ When running your own query file, please specify `query_file = "path/to/your/cds
 
 ### Example: Computing dN/dS values for all orthologous genes between two genomes
 
-First, users can retrieve all coding sequences from entire genomes using the [biomartr](https://github.com/ropensci/biomartr) package ([see details here](https://ropensci.github.io/biomartr/articles/Sequence_Retrieval.html#cds-retrieval)).
+First, users can retrieve all coding sequences from entire genomes using the [biomartr](https://github.com/ropensci/biomartr) package ([see details here](https://docs.ropensci.org/biomartr/articles/Sequence_Retrieval.html#cds-retrieval)).
 
 ```r
 install.packages("biomartr")
@@ -287,7 +287,7 @@ In `orthologr` the file `parseFastaIntoAXT.pl` is stored in `/inst/KaKs_Calc_par
 ```
 The parseFastaIntoAXT.pl script is freely available under GNU GPL v3 
 Licence and included in the KaKs_Calculator project that can be found at 
-https://code.google.com/p/kaks-calculator/
+https://code.google.com/archive/p/kaks-calculator
 
 ```
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,21 +1,24 @@
 citHeader("To cite orthologr in publications please use:")
 
-citEntry(entry = "Article",
-  title        = "Evidence for Active Maintenance of Phylotranscriptomic Hourglass Patterns in Animal and Plant Embryogenesis",
-  author       = personList(as.person("Drost HG"),
-                   as.person("Gabel A"),
-                   as.person("Grosse I"),
-                   as.person("Quint M")),
-  journal      = "Mol. Biol. Evol.",
-  year         = "2015",
-  volume       = "32",
-  number       = "5",
-  pages        = "1221--1231",
-  url          = "http://mbe.oxfordjournals.org/content/32/5/1221",
-  
-  textVersion  =
-  paste("Drost HG, Gabel A, Grosse I, Quint M.",
-  " Evidence for Active Maintenance of Phylotranscriptomic Hourglass Patterns in Animal and Plant Embryogenesis.",
-  " Mol. Biol. Evol. (2015) 32 (5): 1221-1231.",
-  "doi:10.1093/molbev/msv012")
+bibentry(
+  bibtype  = "Article",
+  title    = "Evidence for Active Maintenance of Phylotranscriptomic Hourglass Patterns in Animal and Plant Embryogenesis",
+  author   = c(
+    person("HG", "Drost"),
+    person("A",  "Gabel"),
+    person("I",  "Grosse"),
+    person("M",  "Quint")
+  ),
+  journal  = "Mol. Biol. Evol.",
+  year     = "2015",
+  volume   = "32",
+  number   = "5",
+  pages    = "1221--1231",
+  url      = "https://academic.oup.com/mbe/article/32/5/1221/981502",
+  textVersion = paste(
+    "Drost HG, Gabel A, Grosse I, Quint M.",
+    "Evidence for Active Maintenance of Phylotranscriptomic Hourglass Patterns in Animal and Plant Embryogenesis.",
+    "Mol. Biol. Evol. (2015) 32 (5): 1221-1231.",
+    "doi:10.1093/molbev/msv012"
+  )
 )

--- a/man/blast.Rd
+++ b/man/blast.Rd
@@ -144,9 +144,9 @@ Morgulis A., Coulouris G., Raytselis Y., Madden T.L., Agarwala R., & Schaeffer A
 
 Camacho C., Coulouris G., Avagyan V., Ma N., Papadopoulos J., Bealer K., & Madden T.L. (2008) "BLAST+: architecture and applications." BMC Bioinformatics 10:421.
 
-http://www.ncbi.nlm.nih.gov/books/NBK1763/table/CmdLineAppsManual.T.options_common_to_al/?report=objectonly
+https://www.ncbi.nlm.nih.gov/books/NBK1763/table/CmdLineAppsManual.T.options_common_to_al/?report=objectonly
 
-http://blast.ncbi.nlm.nih.gov/Blast.cgi
+https://blast.ncbi.nlm.nih.gov/Blast.cgi
 }
 \seealso{
 \code{\link{blast_best}}, \code{\link{blast_rec}}, \code{\link{set_blast}}

--- a/man/codon_aln.Rd
+++ b/man/codon_aln.Rd
@@ -90,11 +90,9 @@ codon_aln <- codon_aln(file_aln = system.file('seqs/aa_seqs.aln', package = 'ort
 Mikita Suyama, David Torrents, and Peer Bork (2006)
 PAL2NAL: robust conversion of protein sequence alignments into the corresponding codon alignments. Nucleic Acids Res. 34, W609-W612.
 
-http://www.bork.embl.de/pal2nal/
+https://www.bork.embl.de/services.html
 
-http://www.genome.med.kyoto-u.ac.jp/cgi-bin/suyama/pal2nal/index.cgi
-
-http://abacus.gene.ucl.ac.uk/software/paml.html
+https://github.com/abacus-gene/paml/wiki
 }
 \seealso{
 \code{\link{pairwise_aln}}, \code{\link{multi_aln}}, \code{\link{substitutionrate}},

--- a/man/compute_dnds.Rd
+++ b/man/compute_dnds.Rd
@@ -77,7 +77,7 @@ the query_id and subject_id (file two). These fasta files are then used to pass 
 3) dNdS estimation of the codon alignment returned by 2)
 }
 \references{
-\url{http://www.r-bloggers.com/the-wonders-of-foreach/}
+\url{https://www.r-bloggers.com/2013/08/the-wonders-of-foreach/}
 }
 \seealso{
 \code{\link{multi_aln}}, \code{\link{substitutionrate}}, \code{\link{dNdS}}

--- a/man/dNdS.Rd
+++ b/man/dNdS.Rd
@@ -248,17 +248,17 @@ dNdS(query_file      = system.file('seqs/ortho_thal_cds.fasta', package = 'ortho
 }
 }
 \references{
-seqinr: \url{http://seqinr.r-forge.r-project.org/}
+seqinr: \url{https://cran.r-project.org/package=seqinr}
 
 Zhang Z, Li J, Zhao XQ, Wang J, Wong GK, Yu J: KaKs Calculator: Calculating Ka and Ks through model selection and model averaging. Genomics Proteomics Bioinformatics 2006 , 4:259-263. 
 
-KaKs_Calculator: \url{https://code.google.com/p/kaks-calculator/} [GNU GPL-3 license]
+KaKs_Calculator: \url{https://code.google.com/archive/p/kaks-calculator} [GNU GPL-3 license]
 
 Paradis, E. (2012) Analysis of Phylogenetics and Evolution with R (Second Edition). New York: Springer.
 
 Paradis, E., Claude, J. and Strimmer, K. (2004) APE: analyses of phylogenetics and evolution in R language. Bioinformatics, 20, 289-290.
 
-More information on \pkg{ape} can be found at \url{http://ape-package.ird.fr/}.
+More information on \pkg{ape} can be found at \url{https://emmanuelparadis.github.io/} or \url{https://github.com/emmanuelparadis/ape}.
 
 Pages H, Aboyoun P, Gentleman R and DebRoy S. Biostrings: String objects representing biological sequences, and
 matching algorithms. R package version 2.32.1.

--- a/man/diamond.Rd
+++ b/man/diamond.Rd
@@ -92,7 +92,8 @@ This function gives the same output as \code{\link{blast}} while being up to 10 
 diamond(query_file   = system.file('seqs/ortho_thal_cds.fasta', package = 'orthologr'),
         subject_file = system.file('seqs/ortho_lyra_cds.fasta', package = 'orthologr'))
 
-# performing a DIAMOND2 search using diamond blastp (default) using amino acid sequences as input file
+# performing a DIAMOND2 search using diamond blastp (default) 
+# using amino acid sequences as input file
 diamond(query_file   = system.file('seqs/ortho_thal_aa.fasta', package = 'orthologr'),
         subject_file = system.file('seqs/ortho_lyra_aa.fasta', package = 'orthologr'),
         seq_type     = "protein")

--- a/man/multi_aln.Rd
+++ b/man/multi_aln.Rd
@@ -177,7 +177,7 @@ multi_aln(file    = system.file('seqs/aa_seqs.fasta', package = 'orthologr'),
           path    = "path/to/t_coffee/")
 
 # running t_coffee using additional parameters
-# details: http://www.tcoffee.org/Projects/tcoffee/#DOCUMENTATION
+# details: https://tcoffee.readthedocs.io/en/latest/tcoffee_technical_documentation.html
 multi_aln(file    = system.file('seqs/aa_seqs.fasta', package = 'orthologr'),
           tool    = "t_coffee", 
           get_aln = TRUE,
@@ -199,7 +199,7 @@ multi_aln(file    = system.file('seqs/aa_seqs.fasta', package = 'orthologr'),
           path    = "path/to/muscle/")
 
 # running muscle using additional parameters
-# details: http://www.drive5.com/muscle/manual/
+# details: https://www.drive5.com/muscle/manual/
 multi_aln(file    = system.file('seqs/aa_seqs.fasta', package = 'orthologr'),
           tool    = "muscle", 
           get_aln = TRUE,
@@ -241,7 +241,7 @@ multi_aln(file    = system.file('seqs/aa_seqs.fasta', package = 'orthologr'),
           path    = "path/to/mafft/")
 
 # running mafft using additional parameters
-# details: http://www.drive5.com/mafft/manual/
+# details: https://mafft.cbrc.jp/alignment/software/manual/manual.html
 multi_aln(file    = system.file('seqs/aa_seqs.fasta', package = 'orthologr'),
           tool    = "mafft", 
           get_aln = TRUE,
@@ -258,9 +258,9 @@ Larkin MA, Blackshields G, Brown NP, Chenna R, McGettigan PA, McWilliam H, Valen
 Wallace IM, Wilm A, Lopez R, Thompson JD, Gibson TJ, Higgins DG. (2007).
 Clustal W and Clustal X version 2.0. Bioinformatics, 23, 2947-2948.
 
-\url{http://www.clustal.org/clustal2/}
+\url{https://www.clustal.org/clustal2/}
 
-\url{http://www.ebi.ac.uk/Tools/msa/clustalw2/help/}
+\url{https://www.ebi.ac.uk/jdispatcher/}
 
 
 \item T_COFFEE
@@ -268,9 +268,9 @@ Clustal W and Clustal X version 2.0. Bioinformatics, 23, 2947-2948.
 T-Coffee: A novel method for multiple sequence alignments. 
 Notredame, Higgins, Heringa, JMB, 302(205-217). 2000.
 
-\url{http://www.tcoffee.org/Projects/tcoffee/}
+\url{https://tcoffee.readthedocs.io/en/latest/}
 
-\url{http://www.tcoffee.org/Projects/tcoffee/documentation/t_coffee_tutorial.pdf}
+\url{https://tcoffee.readthedocs.io/en/latest/tcoffee_technical_documentation.html}
 
 
 \item MUSCLE:
@@ -279,9 +279,9 @@ Edgar, R.C. (2004) MUSCLE: multiple sequence alignment with high accuracy and hi
 
 Edgar, R.C. (2004) MUSCLE: a multiple sequence alignment method with reduced time and space complexity. BMC Bioinformatics, (5) 113. 
 
-\url{http://www.drive5.com/muscle/}
+\url{https://www.drive5.com/muscle/}
 
-\url{http://www.drive5.com/muscle/manual/}
+\url{https://www.drive5.com/muscle/manual/}
 
 
 \item CLUSTALO:
@@ -289,20 +289,20 @@ Edgar, R.C. (2004) MUSCLE: a multiple sequence alignment method with reduced tim
 Sievers F, Wilm A, Dineen DG, Gibson TJ, Karplus K, Li W, Lopez R, McWilliam H, Remmert M, Soeding J, Thompson JD, Higgins DG (2011). 
 Fast, scalable generation of high-quality protein multiple sequence alignments using Clustal Omega. Molecular Systems Biology 7:539 doi:10.1038/msb.2011.75
 
-\url{http://www.clustal.org/omega/}
+\url{https://www.ebi.ac.uk/jdispatcher/msa/clustalo/}
 
-\url{http://www.clustal.org/omega/README}
+\url{https://www.genome.jp/tools-bin/clustalw}
 
 \item MAFFT : 
 
 Katoh, Standley 2013 (Molecular Biology and Evolution 30:772-780)  
 MAFFT multiple sequence alignment software version 7: improvements in performance and usability. 
 
-\url{http://mafft.cbrc.jp/alignment/software/}
+\url{https://mafft.cbrc.jp/alignment/software/}
 
-\url{http://mafft.cbrc.jp/alignment/software/manual/manual.html}
+\url{https://mafft.cbrc.jp/alignment/software/manual/manual.html}
 
-\url{http://mafft.cbrc.jp/alignment/software/tips0.html}
+\url{https://mafft.cbrc.jp/alignment/software/tips0.html}
 
 }
 }

--- a/man/orthologs_lnc.Rd
+++ b/man/orthologs_lnc.Rd
@@ -159,17 +159,15 @@ orthologs.lnc(query_file      = system.file('seqs/ortho_thal_cds.fasta', package
 }
 }
 \references{
-BLAST: http://blast.ncbi.nlm.nih.gov/blastcgihelp.shtml
+BLAST: https://blast.ncbi.nlm.nih.gov/blastcgihelp.shtml
 
 ProteinOrtho: https://www.bioinf.uni-leipzig.de/Software/proteinortho/
 
-BLAST: http://blast.ncbi.nlm.nih.gov/blastcgihelp.shtml
+BLAST: https://blast.ncbi.nlm.nih.gov/blastcgihelp.shtml
 
 ProteinOrtho: https://www.bioinf.uni-leipzig.de/Software/proteinortho/
 }
 \seealso{
-\code{\link{blast_rec}}, \code{\link{dNdS}}
-
 \code{\link{blast_rec}}, \code{\link{dNdS}}
 }
 \author{

--- a/man/pairwise_aln.Rd
+++ b/man/pairwise_aln.Rd
@@ -45,8 +45,8 @@ that shall be aligned and computes a paiwise alignment using a defined alignment
 \details{
 This function provides an interface between R and common pairwise alignment computation methods.
 
-The current version of this function computes pairwise alignments based on the \code{\link[Biostrings]{pairwiseAlignment}}
-function implemented in the \pkg{Biostrings} package.
+The current version of this function computes pairwise alignments based on the \code{\link[pwalign]{pairwiseAlignment}}
+function implemented in the \pkg{pwalign} package.
 
 The default pairwise alignment method is based on the \emph{Needleman-Wunsch Algorithm}.
 }

--- a/man/read.cds.Rd
+++ b/man/read.cds.Rd
@@ -28,7 +28,7 @@ of interest as first argument.
 
 It is possible to read in different proteome file standards such as \emph{fasta} or \emph{fastq}.
 
-CDS stored in fasta files can be downloaded from http://www.ensembl.org/info/data/ftp/index.html.
+CDS stored in fasta files can be downloaded from https://www.ensembl.org/info/data/ftp/index.html, etc.
 }
 \examples{
 \dontrun{

--- a/man/read.genome.Rd
+++ b/man/read.genome.Rd
@@ -25,7 +25,7 @@ The \code{read.genome} function takes a string specifying the path to the genome
 of interest as first argument.
 
 It is possible to read in different genome file standards such as \emph{fasta} or \emph{fastq}.
-Genomes stored in fasta files can be downloaded from http://ensemblgenomes.org/info/genomes.
+Genomes stored in fasta files can be downloaded from https://ensemblgenomes.org, https://www.ncbi.nlm.nih.gov/genome, or https://www.ebi.ac.uk, etc.
 }
 \examples{
 \dontrun{

--- a/man/read.proteome.Rd
+++ b/man/read.proteome.Rd
@@ -26,7 +26,7 @@ of interest as first argument.
 
 It is possible to read in different proteome file standards such as \emph{fasta} or \emph{fastq}.
 
-Proteomes stored in fasta files can be downloaded from http://www.ebi.ac.uk/reference_proteomes.
+Proteomes stored in fasta files can be downloaded from https://www.ebi.ac.uk/reference_proteomes, etc.
 }
 \examples{
 \dontrun{

--- a/man/substitutionrate.Rd
+++ b/man/substitutionrate.Rd
@@ -138,9 +138,7 @@ Thornton, K. (2003) libsequence: a C++ class library for evolutionary genetic an
 Zhang Z, Li J, Zhao XQ, Wang J, Wong GK, Yu J: KaKs Calculator:
 Calculating Ka and Ks through model selection and model averaging. Genomics Proteomics Bioinformatics 2006 , 4:259-263.
 
-https://code.google.com/p/kaks-calculator/wiki/KaKs_Calculator
-
-https://code.google.com/p/kaks-calculator/wiki/AXT
+https://code.google.com/archive/p/kaks-calculator
 }
 \seealso{
 \code{\link{dNdS}}, \code{\link{multi_aln}}, \code{\link{codon_aln}}, \code{\link{blast_best}},

--- a/tests/testthat/test-blast.R
+++ b/tests/testthat/test-blast.R
@@ -1,9 +1,6 @@
 context("Test: blast()")
 
-blast_available <- tryCatch({
-        is_installed_blast()
-        TRUE
-}, error = function(e) FALSE)
+blast_available <- isTRUE(tryCatch(is_installed_blast(), error = function(e) FALSE))
 
 test_that("blast() runs properly ...", {
         skip_if_not(blast_available, "BLAST is not installed or not on PATH")

--- a/tests/testthat/test-blast.R
+++ b/tests/testthat/test-blast.R
@@ -1,11 +1,15 @@
 context("Test: blast()")
 
-test_that(
-        "blast() runs properly ...",
-        {
-                test_blast <- blast(query_file   = system.file('seqs/ortho_thal_cds.fasta', package = 'orthologr'),
-                                    subject_file = system.file('seqs/ortho_lyra_cds.fasta', package = 'orthologr'))
-                
-                expect_true(tibble::is_tibble(test_blast))
-        }
-)
+blast_available <- tryCatch({
+        is_installed_blast()
+        TRUE
+}, error = function(e) FALSE)
+
+test_that("blast() runs properly ...", {
+        skip_if_not(blast_available, "BLAST is not installed or not on PATH")
+        test_blast <- blast(
+                query_file   = system.file('seqs/ortho_thal_cds.fasta', package = 'orthologr'),
+                subject_file = system.file('seqs/ortho_lyra_cds.fasta', package = 'orthologr')
+        )
+        expect_true(tibble::is_tibble(test_blast))
+})

--- a/tests/testthat/test-blast_best.R
+++ b/tests/testthat/test-blast_best.R
@@ -1,9 +1,6 @@
 context("Test: blast_best()")
 
-blast_available <- tryCatch({
-        is_installed_blast()
-        TRUE
-}, error = function(e) FALSE)
+blast_available <- isTRUE(tryCatch(is_installed_blast(), error = function(e) FALSE))
 
 test_that("blast_best() runs properly ...", {
         skip_if_not(blast_available, "BLAST is not installed or not on PATH")

--- a/tests/testthat/test-blast_best.R
+++ b/tests/testthat/test-blast_best.R
@@ -1,1 +1,16 @@
 context("Test: blast_best()")
+
+blast_available <- tryCatch({
+        is_installed_blast()
+        TRUE
+}, error = function(e) FALSE)
+
+test_that("blast_best() runs properly ...", {
+        skip_if_not(blast_available, "BLAST is not installed or not on PATH")
+        result <- blast_best(
+                query_file   = system.file('seqs/ortho_thal_cds.fasta', package = 'orthologr'),
+                subject_file = system.file('seqs/ortho_lyra_cds.fasta', package = 'orthologr')
+        )
+        expect_true(tibble::is_tibble(result))
+        expect_equal(nrow(result), dplyr::n_distinct(result[["query_id"]]))
+})

--- a/tests/testthat/test-blast_rec.R
+++ b/tests/testthat/test-blast_rec.R
@@ -1,9 +1,6 @@
 context("Test: blast_rec()")
 
-blast_available <- tryCatch({
-        is_installed_blast()
-        TRUE
-}, error = function(e) FALSE)
+blast_available <- isTRUE(tryCatch(is_installed_blast(), error = function(e) FALSE))
 
 test_that("blast_rec() runs properly ...", {
         skip_if_not(blast_available, "BLAST is not installed or not on PATH")

--- a/tests/testthat/test-blast_rec.R
+++ b/tests/testthat/test-blast_rec.R
@@ -1,1 +1,15 @@
 context("Test: blast_rec()")
+
+blast_available <- tryCatch({
+        is_installed_blast()
+        TRUE
+}, error = function(e) FALSE)
+
+test_that("blast_rec() runs properly ...", {
+        skip_if_not(blast_available, "BLAST is not installed or not on PATH")
+        result <- blast_rec(
+                query_file   = system.file('seqs/ortho_thal_cds.fasta', package = 'orthologr'),
+                subject_file = system.file('seqs/ortho_lyra_cds.fasta', package = 'orthologr')
+        )
+        expect_true(tibble::is_tibble(result))
+})

--- a/tests/testthat/test-diamond.R
+++ b/tests/testthat/test-diamond.R
@@ -1,0 +1,113 @@
+context("Test: diamond()")
+
+cds_file     <- system.file("seqs/ortho_thal_cds.fasta", package = "orthologr")
+subject_cds  <- system.file("seqs/ortho_lyra_cds.fasta", package = "orthologr")
+protein_file <- system.file("seqs/ortho_thal_aa.fasta",  package = "orthologr")
+subject_prot <- system.file("seqs/ortho_lyra_aa.fasta",  package = "orthologr")
+
+expected_cols <- c(
+        "query_id", "subject_id", "perc_identity", "num_ident_matches",
+        "alig_length", "mismatches", "gap_openings", "n_gaps", "pos_match",
+        "ppos", "q_start", "q_end", "q_len", "qcov", "qcovhsp",
+        "s_start", "s_end", "s_len", "evalue", "bit_score", "score_raw"
+)
+
+diamond_available <- tryCatch({
+        is_installed_diamond()
+        TRUE
+}, error = function(e) FALSE)
+
+# --- Input validation (no DIAMOND needed) ------------------------------------
+
+test_that("diamond() errors on invalid diamond_algorithm", {
+        expect_error(
+                diamond(query_file = cds_file, subject_file = subject_cds,
+                        diamond_algorithm = "blastn"),
+                regexp = "valid DIAMOND mode"
+        )
+})
+
+test_that("diamond() errors on invalid database_maker", {
+        expect_error(
+                diamond(query_file = cds_file, subject_file = subject_cds,
+                        database_maker = "hmmer"),
+                regexp = "Please choose either"
+        )
+})
+
+# --- Output structure --------------------------------------------------------
+
+test_that("diamond() returns a tibble with CDS input", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond(query_file = cds_file, subject_file = subject_cds)
+        expect_true(tibble::is_tibble(result))
+})
+
+test_that("diamond() output has exactly 21 expected columns", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond(query_file = cds_file, subject_file = subject_cds)
+        expect_equal(colnames(result), expected_cols)
+})
+
+test_that("diamond() output is non-empty for related sequences", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond(query_file = cds_file, subject_file = subject_cds)
+        expect_gt(nrow(result), 0L)
+})
+
+test_that("diamond() query_id and subject_id columns are character", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond(query_file = cds_file, subject_file = subject_cds)
+        expect_type(result[["query_id"]],   "character")
+        expect_type(result[["subject_id"]], "character")
+})
+
+test_that("diamond() evalue column respects the e-value cutoff", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond(query_file = cds_file, subject_file = subject_cds,
+                          eval = "1E-5")
+        expect_true(all(result[["evalue"]] <= 1e-5))
+})
+
+test_that("diamond() perc_identity is between 0 and 100", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond(query_file = cds_file, subject_file = subject_cds)
+        expect_true(all(result[["perc_identity"]] >= 0))
+        expect_true(all(result[["perc_identity"]] <= 100))
+})
+
+# --- Protein sequence input --------------------------------------------------
+
+test_that("diamond() runs with seq_type = 'protein'", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond(
+                query_file   = protein_file,
+                subject_file = subject_prot,
+                seq_type     = "protein"
+        )
+        expect_true(tibble::is_tibble(result))
+        expect_equal(colnames(result), expected_cols)
+        expect_gt(nrow(result), 0L)
+})
+
+# --- Sensitivity modes -------------------------------------------------------
+
+test_that("diamond() runs with sensitivity_mode = 'sensitive'", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond(
+                query_file       = cds_file,
+                subject_file     = subject_cds,
+                sensitivity_mode = "sensitive"
+        )
+        expect_true(tibble::is_tibble(result))
+        expect_gt(nrow(result), 0L)
+})
+
+test_that("diamond() with 'more-sensitive' mode returns at least as many hits as 'fast' mode", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result_fast      <- diamond(query_file = cds_file, subject_file = subject_cds,
+                                    sensitivity_mode = "fast")
+        result_sensitive <- diamond(query_file = cds_file, subject_file = subject_cds,
+                                    sensitivity_mode = "more-sensitive")
+        expect_gte(nrow(result_sensitive), nrow(result_fast))
+})

--- a/tests/testthat/test-diamond.R
+++ b/tests/testthat/test-diamond.R
@@ -12,10 +12,7 @@ expected_cols <- c(
         "s_start", "s_end", "s_len", "evalue", "bit_score", "score_raw"
 )
 
-diamond_available <- tryCatch({
-        is_installed_diamond()
-        TRUE
-}, error = function(e) FALSE)
+diamond_available <- isTRUE(tryCatch(is_installed_diamond(), error = function(e) FALSE))
 
 # --- Input validation (no DIAMOND needed) ------------------------------------
 

--- a/tests/testthat/test-diamond_best.R
+++ b/tests/testthat/test-diamond_best.R
@@ -1,0 +1,54 @@
+context("Test: diamond_best()")
+
+cds_file     <- system.file("seqs/ortho_thal_cds.fasta", package = "orthologr")
+subject_cds  <- system.file("seqs/ortho_lyra_cds.fasta", package = "orthologr")
+protein_file <- system.file("seqs/ortho_thal_aa.fasta",  package = "orthologr")
+subject_prot <- system.file("seqs/ortho_lyra_aa.fasta",  package = "orthologr")
+
+diamond_available <- tryCatch({
+        is_installed_diamond()
+        TRUE
+}, error = function(e) FALSE)
+
+test_that("diamond_best() returns a tibble with CDS input", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond_best(query_file = cds_file, subject_file = subject_cds)
+        expect_true(tibble::is_tibble(result))
+})
+
+test_that("diamond_best() output is non-empty for related sequences", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond_best(query_file = cds_file, subject_file = subject_cds)
+        expect_gt(nrow(result), 0L)
+})
+
+test_that("diamond_best() returns at most one hit per query_id", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond_best(query_file = cds_file, subject_file = subject_cds)
+        expect_equal(nrow(result), dplyr::n_distinct(result[["query_id"]]))
+})
+
+test_that("diamond_best() returns fewer or equal hits compared to diamond()", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        all_hits  <- diamond(query_file = cds_file, subject_file = subject_cds)
+        best_hits <- diamond_best(query_file = cds_file, subject_file = subject_cds)
+        expect_lte(nrow(best_hits), nrow(all_hits))
+})
+
+test_that("diamond_best() has query_id column of type character", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond_best(query_file = cds_file, subject_file = subject_cds)
+        expect_type(result[["query_id"]], "character")
+})
+
+test_that("diamond_best() runs with seq_type = 'protein'", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond_best(
+                query_file   = protein_file,
+                subject_file = subject_prot,
+                seq_type     = "protein"
+        )
+        expect_true(tibble::is_tibble(result))
+        expect_gt(nrow(result), 0L)
+        expect_equal(nrow(result), dplyr::n_distinct(result[["query_id"]]))
+})

--- a/tests/testthat/test-diamond_best.R
+++ b/tests/testthat/test-diamond_best.R
@@ -5,10 +5,7 @@ subject_cds  <- system.file("seqs/ortho_lyra_cds.fasta", package = "orthologr")
 protein_file <- system.file("seqs/ortho_thal_aa.fasta",  package = "orthologr")
 subject_prot <- system.file("seqs/ortho_lyra_aa.fasta",  package = "orthologr")
 
-diamond_available <- tryCatch({
-        is_installed_diamond()
-        TRUE
-}, error = function(e) FALSE)
+diamond_available <- isTRUE(tryCatch(is_installed_diamond(), error = function(e) FALSE))
 
 test_that("diamond_best() returns a tibble with CDS input", {
         skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")

--- a/tests/testthat/test-diamond_rec.R
+++ b/tests/testthat/test-diamond_rec.R
@@ -1,0 +1,62 @@
+context("Test: diamond_rec()")
+
+cds_file     <- system.file("seqs/ortho_thal_cds.fasta", package = "orthologr")
+subject_cds  <- system.file("seqs/ortho_lyra_cds.fasta", package = "orthologr")
+protein_file <- system.file("seqs/ortho_thal_aa.fasta",  package = "orthologr")
+subject_prot <- system.file("seqs/ortho_lyra_aa.fasta",  package = "orthologr")
+
+diamond_available <- tryCatch({
+        is_installed_diamond()
+        TRUE
+}, error = function(e) FALSE)
+
+test_that("diamond_rec() returns a tibble with CDS input", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond_rec(query_file = cds_file, subject_file = subject_cds)
+        expect_true(tibble::is_tibble(result))
+})
+
+test_that("diamond_rec() output is non-empty for related sequences", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond_rec(query_file = cds_file, subject_file = subject_cds)
+        expect_gt(nrow(result), 0L)
+})
+
+test_that("diamond_rec() returns fewer or equal hits than diamond_best()", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        bh  <- diamond_best(query_file = cds_file, subject_file = subject_cds)
+        rbh <- diamond_rec(query_file  = cds_file, subject_file = subject_cds)
+        expect_lte(nrow(rbh), nrow(bh))
+})
+
+test_that("diamond_rec() query_id and subject_id are unique pairs", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond_rec(query_file = cds_file, subject_file = subject_cds)
+        n_pairs <- dplyr::n_distinct(result[["query_id"]], result[["subject_id"]])
+        expect_equal(nrow(result), n_pairs)
+})
+
+test_that("diamond_rec() all query_ids are unique (each gene has one RBH)", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond_rec(query_file = cds_file, subject_file = subject_cds)
+        expect_equal(nrow(result), dplyr::n_distinct(result[["query_id"]]))
+})
+
+test_that("diamond_rec() runs with seq_type = 'protein'", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- diamond_rec(
+                query_file   = protein_file,
+                subject_file = subject_prot,
+                seq_type     = "protein"
+        )
+        expect_true(tibble::is_tibble(result))
+        expect_gt(nrow(result), 0L)
+})
+
+test_that("diamond_rec() RBH pairs are a subset of forward BH pairs", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        bh  <- diamond_best(query_file = cds_file, subject_file = subject_cds)
+        rbh <- diamond_rec(query_file  = cds_file, subject_file = subject_cds)
+        # Every RBH query_id must appear in BH
+        expect_true(all(rbh[["query_id"]] %in% bh[["query_id"]]))
+})

--- a/tests/testthat/test-diamond_rec.R
+++ b/tests/testthat/test-diamond_rec.R
@@ -5,10 +5,7 @@ subject_cds  <- system.file("seqs/ortho_lyra_cds.fasta", package = "orthologr")
 protein_file <- system.file("seqs/ortho_thal_aa.fasta",  package = "orthologr")
 subject_prot <- system.file("seqs/ortho_lyra_aa.fasta",  package = "orthologr")
 
-diamond_available <- tryCatch({
-        is_installed_diamond()
-        TRUE
-}, error = function(e) FALSE)
+diamond_available <- isTRUE(tryCatch(is_installed_diamond(), error = function(e) FALSE))
 
 test_that("diamond_rec() returns a tibble with CDS input", {
         skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")

--- a/tests/testthat/test-filter_dNdS.R
+++ b/tests/testthat/test-filter_dNdS.R
@@ -1,1 +1,48 @@
 context("Test: filter_dNdS()")
+
+# Build a minimal mock dNdS table matching the columns filter_dNdS() uses
+mock_dnds <- tibble::tibble(
+        query_id   = paste0("gene", 1:6),
+        subject_id = paste0("subj", 1:6),
+        dN         = c(0.01, 0.02, NA,   0.05, 0.10, 0.00),
+        dS         = c(0.10, NA,   0.30, 0.20, 0.50, 0.00),
+        dNdS       = c(0.10, NA,   NA,   0.25, 0.20, NA)
+)
+
+test_that("filter_dNdS() returns a data frame / tibble", {
+        result <- filter_dNdS(mock_dnds, dnds.threshold = 2)
+        expect_true(is.data.frame(result))
+})
+
+test_that("filter_dNdS() removes rows with NA in dN", {
+        result <- filter_dNdS(mock_dnds, dnds.threshold = 2)
+        expect_false(any(is.na(result[["dN"]])))
+})
+
+test_that("filter_dNdS() removes rows with NA in dS", {
+        result <- filter_dNdS(mock_dnds, dnds.threshold = 2)
+        expect_false(any(is.na(result[["dS"]])))
+})
+
+test_that("filter_dNdS() removes rows where dNdS > threshold", {
+        result <- filter_dNdS(mock_dnds, dnds.threshold = 0.15)
+        expect_true(all(result[["dNdS"]] <= 0.15))
+})
+
+test_that("filter_dNdS() retains rows that pass all filters", {
+        result <- filter_dNdS(mock_dnds, dnds.threshold = 2)
+        # gene1: dN=0.01, dS=0.10, dNdS=0.10 -> should be retained
+        expect_true("gene1" %in% result[["query_id"]])
+})
+
+test_that("filter_dNdS() with a very low threshold removes high dNdS rows", {
+        result <- filter_dNdS(mock_dnds, dnds.threshold = 0.05)
+        expect_true(nrow(result) < nrow(mock_dnds))
+})
+
+test_that("filter_dNdS() with threshold = Inf retains all non-NA rows", {
+        result_all_na_removed <- dplyr::filter(mock_dnds,
+                                               !is.na(dN), !is.na(dS), !is.na(dNdS))
+        result <- filter_dNdS(mock_dnds, dnds.threshold = Inf)
+        expect_equal(nrow(result), nrow(result_all_na_removed))
+})

--- a/tests/testthat/test-is_installed_diamond.R
+++ b/tests/testthat/test-is_installed_diamond.R
@@ -1,0 +1,19 @@
+context("Test: is_installed_diamond()")
+
+diamond_available <- tryCatch({
+        is_installed_diamond()
+        TRUE
+}, error = function(e) FALSE)
+
+test_that("is_installed_diamond() returns TRUE when DIAMOND2 is on PATH", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        expect_true(is_installed_diamond())
+})
+
+test_that("is_installed_diamond() returns TRUE when a valid exec path is provided", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        # Resolve the actual path diamond lives on so we can pass it explicitly
+        diamond_path <- dirname(Sys.which("diamond"))
+        skip_if(nchar(diamond_path) == 0, "Could not resolve diamond PATH")
+        expect_true(is_installed_diamond(diamond_exec_path = diamond_path))
+})

--- a/tests/testthat/test-is_installed_diamond.R
+++ b/tests/testthat/test-is_installed_diamond.R
@@ -1,9 +1,6 @@
 context("Test: is_installed_diamond()")
 
-diamond_available <- tryCatch({
-        is_installed_diamond()
-        TRUE
-}, error = function(e) FALSE)
+diamond_available <- isTRUE(tryCatch(is_installed_diamond(), error = function(e) FALSE))
 
 test_that("is_installed_diamond() returns TRUE when DIAMOND2 is on PATH", {
         skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")

--- a/tests/testthat/test-read.cds.R
+++ b/tests/testthat/test-read.cds.R
@@ -1,1 +1,51 @@
 context("Test: read.cds()")
+
+cds_file <- system.file("seqs/ortho_thal_cds.fasta", package = "orthologr")
+
+test_that("read.cds() returns a data.table", {
+        result <- read.cds(file = cds_file, format = "fasta")
+        expect_true(data.table::is.data.table(result))
+})
+
+test_that("read.cds() output has columns 'geneids' and 'seqs'", {
+        result <- read.cds(file = cds_file, format = "fasta")
+        expect_true("geneids" %in% colnames(result))
+        expect_true("seqs"    %in% colnames(result))
+})
+
+test_that("read.cds() returns non-empty data for a valid file", {
+        result <- read.cds(file = cds_file, format = "fasta")
+        expect_gt(nrow(result), 0L)
+})
+
+test_that("read.cds() 'seqs' column contains lowercase nucleotide strings", {
+        result <- read.cds(file = cds_file, format = "fasta")
+        # All characters should be lowercase a/c/g/t
+        expect_true(all(grepl("^[acgt]+$", result[["seqs"]])))
+})
+
+test_that("read.cds() geneids are unique", {
+        result <- read.cds(file = cds_file, format = "fasta")
+        expect_equal(length(unique(result[["geneids"]])), nrow(result))
+})
+
+test_that("read.cds() errors on a non-existent file", {
+        expect_error(
+                read.cds(file = "nonexistent.fasta", format = "fasta"),
+                regexp = "seems not to exist|does not seem to exist|could not be read"
+        )
+})
+
+test_that("read.cds() errors on an unsupported format", {
+        expect_error(
+                read.cds(file = cds_file, format = "genbank"),
+                regexp = "supported"
+        )
+})
+
+test_that("read.cds() with delete_corrupt_cds = TRUE returns only triplet-length sequences", {
+        result <- read.cds(file = cds_file, format = "fasta",
+                           delete_corrupt_cds = TRUE)
+        # All retained sequences should have length divisible by 3
+        expect_true(all(nchar(result[["seqs"]]) %% 3 == 0))
+})

--- a/tests/testthat/test-set_diamond.R
+++ b/tests/testthat/test-set_diamond.R
@@ -1,0 +1,84 @@
+context("Test: set_diamond()")
+
+cds_file     <- system.file("seqs/ortho_thal_cds.fasta",  package = "orthologr")
+protein_file <- system.file("seqs/ortho_thal_aa.fasta",   package = "orthologr")
+
+diamond_available <- tryCatch({
+        is_installed_diamond()
+        TRUE
+}, error = function(e) FALSE)
+
+# --- Input validation (no DIAMOND needed) ------------------------------------
+
+test_that("set_diamond() errors on non-existent file", {
+        expect_error(
+                set_diamond(file = "nonexistent_file.fasta"),
+                regexp = "seems not to exist"
+        )
+})
+
+test_that("set_diamond() errors on invalid seq_type", {
+        expect_error(
+                set_diamond(file = cds_file, seq_type = "rna"),
+                regexp = "Please choose either"
+        )
+})
+
+test_that("set_diamond() errors on invalid makedb_type", {
+        expect_error(
+                set_diamond(file = cds_file, makedb_type = "nucleotide"),
+                regexp = "valid DIAMOND database type"
+        )
+})
+
+# --- Output structure with seq_type = "cds" (no makedb) ----------------------
+
+test_that("set_diamond() returns a list of length 2 for CDS input", {
+        result <- set_diamond(file = cds_file, seq_type = "cds")
+        expect_type(result, "list")
+        expect_length(result, 2L)
+})
+
+test_that("set_diamond()[[1]] is a data.table with expected columns (CDS)", {
+        result <- set_diamond(file = cds_file, seq_type = "cds")
+        dt <- result[[1]]
+        expect_true(data.table::is.data.table(dt))
+        expect_true(all(c("geneids", "seqs", "aa") %in% colnames(dt)))
+})
+
+test_that("set_diamond() returns non-empty sequence data for CDS input", {
+        result <- set_diamond(file = cds_file, seq_type = "cds")
+        expect_gt(nrow(result[[1]]), 0L)
+})
+
+test_that("set_diamond() translated amino acids are character strings", {
+        result <- set_diamond(file = cds_file, seq_type = "cds")
+        expect_true(is.character(result[[1]][["aa"]]))
+})
+
+# --- Output structure with seq_type = "protein" (no makedb) ------------------
+
+test_that("set_diamond() returns a list of length 2 for protein input", {
+        result <- set_diamond(file = protein_file, seq_type = "protein")
+        expect_type(result, "list")
+        expect_length(result, 2L)
+})
+
+test_that("set_diamond()[[1]] has columns geneids and aa for protein input", {
+        result <- set_diamond(file = protein_file, seq_type = "protein")
+        dt <- result[[1]]
+        expect_true(data.table::is.data.table(dt))
+        expect_true(all(c("geneids", "aa") %in% colnames(dt)))
+        expect_gt(nrow(dt), 0L)
+})
+
+# --- makedb = TRUE (requires DIAMOND) ----------------------------------------
+
+test_that("set_diamond() with makedb = TRUE creates a database file", {
+        skip_if_not(diamond_available, "DIAMOND2 is not installed or not on PATH")
+        result <- set_diamond(file = protein_file, seq_type = "protein", makedb = TRUE)
+        dbname <- result[[2]]
+        expect_true(nchar(dbname) > 0)
+        db_path <- file.path(tempdir(), "_blast_db", paste0(dbname, ".dmnd"))
+        expect_true(file.exists(db_path))
+})

--- a/tests/testthat/test-set_diamond.R
+++ b/tests/testthat/test-set_diamond.R
@@ -3,10 +3,7 @@ context("Test: set_diamond()")
 cds_file     <- system.file("seqs/ortho_thal_cds.fasta",  package = "orthologr")
 protein_file <- system.file("seqs/ortho_thal_aa.fasta",   package = "orthologr")
 
-diamond_available <- tryCatch({
-        is_installed_diamond()
-        TRUE
-}, error = function(e) FALSE)
+diamond_available <- isTRUE(tryCatch(is_installed_diamond(), error = function(e) FALSE))
 
 # --- Input validation (no DIAMOND needed) ------------------------------------
 

--- a/tests/testthat/test-transl.R
+++ b/tests/testthat/test-transl.R
@@ -1,1 +1,43 @@
 context("Test: transl()")
+
+test_that("transl() returns a character string", {
+        result <- transl("ATGATG")
+        expect_type(result, "character")
+        expect_length(result, 1L)
+})
+
+test_that("transl() output length equals input length / 3", {
+        seq <- "ATGATGATG"  # 9 nt -> 3 aa
+        result <- transl(seq)
+        expect_equal(nchar(result), nchar(seq) / 3)
+})
+
+test_that("transl() correctly translates ATG (Met start codon)", {
+        # ATG encodes Methionine (M)
+        result <- transl("ATG")
+        expect_equal(toupper(result), "M")
+})
+
+test_that("transl() correctly translates a known dipeptide", {
+        # ATG = M (Met), AAA = K (Lys)
+        result <- transl("ATGAAA")
+        expect_equal(toupper(result), "MK")
+})
+
+test_that("transl() translates a stop codon to '*'", {
+        # TAA is a canonical stop codon
+        result <- transl("TAA")
+        expect_equal(result, "*")
+})
+
+test_that("transl() handles a full ORF (start + coding + stop)", {
+        # ATG (M) + GGT (G) + TAA (*)
+        result <- transl("ATGGGTTAA")
+        expect_equal(toupper(result), "MG*")
+})
+
+test_that("transl() output matches seqinr::translate() directly", {
+        seq <- "ATGAAAGGG"
+        expected <- seqinr::c2s(seqinr::translate(seqinr::s2c(seq)))
+        expect_equal(transl(seq), expected)
+})

--- a/tests/testthat/test-translate_cds_to_protein.R
+++ b/tests/testthat/test-translate_cds_to_protein.R
@@ -1,1 +1,54 @@
 context("Test: translate_cds_to_protein()")
+
+cds_file <- system.file("seqs/ortho_thal_cds.fasta", package = "orthologr")
+
+test_that("translate_cds_to_protein() errors on a non-existent input file", {
+        expect_error(
+                translate_cds_to_protein("nonexistent_cds.fasta", tempfile(fileext = ".fasta")),
+                regexp = "seems not to exist"
+        )
+})
+
+test_that("translate_cds_to_protein() creates an output file", {
+        out <- tempfile(fileext = ".fasta")
+        on.exit(unlink(out))
+        translate_cds_to_protein(input_file = cds_file, output_file = out)
+        expect_true(file.exists(out))
+})
+
+test_that("translate_cds_to_protein() output is a non-empty FASTA file", {
+        out <- tempfile(fileext = ".fasta")
+        on.exit(unlink(out))
+        translate_cds_to_protein(input_file = cds_file, output_file = out)
+        aa_seqs <- Biostrings::readAAStringSet(out)
+        expect_gt(length(aa_seqs), 0L)
+})
+
+test_that("translate_cds_to_protein() output contains only amino acid characters", {
+        out <- tempfile(fileext = ".fasta")
+        on.exit(unlink(out))
+        translate_cds_to_protein(input_file = cds_file, output_file = out)
+        aa_seqs <- Biostrings::readAAStringSet(out)
+        # All sequences should be of class AAStringSet (Biostrings validates this)
+        expect_s4_class(aa_seqs, "AAStringSet")
+})
+
+test_that("translate_cds_to_protein() output has same number of sequences as input", {
+        out <- tempfile(fileext = ".fasta")
+        on.exit(unlink(out))
+        translate_cds_to_protein(input_file = cds_file, output_file = out,
+                                 delete_corrupt_cds = FALSE)
+        cds_in <- Biostrings::readDNAStringSet(cds_file)
+        aa_out <- Biostrings::readAAStringSet(out)
+        expect_equal(length(aa_out), length(cds_in))
+})
+
+test_that("translate_cds_to_protein() output has 1/3 width as input (since 3 nucleotides corresponds to one amino acid)", {
+        out <- tempfile(fileext = ".fasta")
+        on.exit(unlink(out))
+        translate_cds_to_protein(input_file = cds_file, output_file = out,
+                                 delete_corrupt_cds = FALSE)
+        cds_in <- Biostrings::readDNAStringSet(cds_file)
+        aa_out <- Biostrings::readAAStringSet(out)
+        expect_equal(width(aa_out), width(cds_in) / 3)
+})

--- a/vignettes/Install.Rmd
+++ b/vignettes/Install.Rmd
@@ -28,9 +28,9 @@ and execute test cases that are presented in each section.__
 The following bioinformatics tools you are going to install are based on
 the these programming languages:
 
- - [__R__](http://www.cran.r-project.org) >= 3.1.1
+ - [__R__](https://cran.r-project.org) >= 3.1.1
  
- - [__C++11__](http://isocpp.org/about)
+ - [__C++11__](https://isocpp.org/about)
  
  - [__Perl__](https://www.perl.org) >= 5.12
  
@@ -42,17 +42,18 @@ The `orthologr` package provides interfaces to the pairwise alignment tools, `BL
 
 ### Install `BLAST`
 
-[__BLAST__](http://www.ncbi.nlm.nih.gov/guide/howto/run-blast-local/]) (= Basic Local Alignment Search Tool) finds regions of similarity between biological sequences and is also used as underlying paradigm of most orthology inference methods.
+[__BLAST__](https://www.ncbi.nlm.nih.gov/guide/howto/run-blast-local/]) (= Basic Local Alignment Search Tool) finds regions of similarity between biological sequences and is also used as underlying paradigm of most orthology inference methods.
 
-1) Go to ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ and download the system specific BLAST program.
+1) Go to https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ and download the system specific BLAST program.
 
 2) Install BLAST :  
 
-* On a Windows machine (see [installation manual: Windows](http://www.ncbi.nlm.nih.gov/books/NBK52637/))
+* On a Windows machine (see [installation manual: Windows](https://www.ncbi.nlm.nih.gov/books/NBK52637/))
 -> Please carefully read the `Environment Variables` section of the `installation manual: Windows` and make sure the execution `PATH` variable is set correctly.
-* On a Unix machine (see [installation manual: Unix](http://www.ncbi.nlm.nih.gov/books/NBK52640/)) 
+* On a Unix machine (see [installation manual: Unix](https://www.ncbi.nlm.nih.gov/books/NBK52640/)) 
 -> Please carefully read the `Configuration` section of the `installation manual: Unix` and make sure the execution `PATH` variable is set correctly to `usr/local/bin`.
 
+<details> <summary>Example on Linux systems for BLAST+ version 2.2.31</summary>
 For example for Linux systems open the `Terminal` application and run (Thanks to Alexander Gabel):
 
 ```
@@ -65,6 +66,7 @@ tar zxvpf ncbi-blast+2.2.31+-x64-linux.tar.gz
 # copy BLAST files to `usr/local/bin`
 cp ncbi-blast-2.2.31+/bin/* usr/local/bin
 ```
+</details>
 
 Alternatively users can set the system call to the BLAST programs by specifying the `PATH` variable (this is useful, because it allows an easier update of BLAST versions instead of deleting all BLAST programs from `usr/local/bin`):
 
@@ -102,6 +104,26 @@ open /usr/local/bin
 
 Next, copy/paste the `blastp`, `makeblastdb`, etc files (BLAST executables) from your BLAST folder to `/usr/local/bin`. To do so you will need to enter the system password to allow the copy process.
 
+<details> <summary>Additional tips for macOS</summary>
+While one can install BLAST+ via `brewer` and other package managers, we recommend to install BLAST+ manually. Select `aarch64-macosx` for Apple Silicon (M1/M2/M3 etc.) and `x64-macosx` for Intel-based Macs. 
+
+If you cannot run BLAST+, e.g. `blastp`, due to the message "Apple could not verify “blastp” is free of malware that may harm your Mac or compromise your privacy", consider navigating to the directory where `blastp` is located using the terminal and running a clear the quarantine flag `xattr -r -d com.apple.quarantine .`. There may be other solutions.
+
+In addition, you may want to add BLAST+ to the .Renviron file to make sure that BLAST+ is available in R sessions. To do so, open the R and type:
+
+```R
+library(usethis)
+# open the .Renviron file for editing
+usethis::edit_r_environ()
+```
+
+In the .Renviron file add the following line (make sure to change the path to the BLAST+ bin folder):
+
+```
+# e.g., for BLAST+ version 2.17.0+ installed in the Downloads folder of the user "user"
+PATH="/Users/User/Downloads/ncbi-blast-2.17.0+/bin:${PATH}"
+```
+</details>
 
 After installing the BLAST program you can open an R session and type the following command to check whether or not BLAST can be executed from R.
 
@@ -132,11 +154,7 @@ These interface functions to BLAST+ are implemented in `orthologr`:
  - `blast_best()` : Perform a BLAST+ best hit search
  - `blast_rec()` : Perform a BLAST+ reciprocal best hit (RBH) search
  - `set_blast()` : Preparing the parameters and databases for subsequent BLAST+ searches
- - `blast.nr()` : Perform a BLASTp search against NCBI nr
- - `delta.blast()` : Perform a DELTA-BLAST Search
- - `advanced_blast()` : Advanced interface function to BLAST+
- - `advanced_makedb()` : Advanced interface function to makeblastdb
- 
+
 ### Install `DIAMOND2`
 
 [__DIAMOND2__](https://github.com/bbuchfink/diamond) (= Double Index alignment of Next-generation sequencing data) finds, like `BLAST`, regions of similarity between biological sequences. Unlike `BLAST` it is much much faster (up to 10 000X faster in the default `fast` mode and over 80X faster in the `ultra-sensitive` mode, which is as sensitive as `BLAST`). Thus, `DIAMOND2` facilitates _even faster_ orthology inference.
@@ -148,6 +166,8 @@ These interface functions to BLAST+ are implemented in `orthologr`:
 ```
 diamond --version
 ```
+
+Check the `Additional tips for macOS` section in the `BLAST` installation instructions for macOS users, because similar issues may arise when installing `DIAMOND2` on macOS.
 
 3) After installing the `DIAMOND2` program you can open an R session and type the following command to check whether or not `DIAMOND2` can be executed from R.
 
@@ -191,8 +211,7 @@ are not used.
 
 ### Install `ClustalW2`
 
-To install `ClustalW2` please go to the [ClustalW](http://www.clustal.org/clustal2/) homepage and download
-the corresponding [clustalw2 program](http://www.clustal.org/download/current/) matching your operating system.
+To install `ClustalW2` please download via a package manager (e.g. brewer, conda) since the ClustalW homepage is no longer available. However, if you are somehow able to obtain the `clustalw2` program that matches your operating system, you can install it by following the instructions below.
 
 After downloading and unpacking the `clustalw2` program, please go to the clustalw-2.1 folder and open a `Terminal` application
 to type (in this example for Mac OS X):
@@ -204,19 +223,19 @@ cp clustalw2 usr/local/bin
 
 ### Install `T-Coffee`
 
-To install `T-Coffee` please go to the [T-Coffee](http://www.tcoffee.org/Projects/tcoffee/) homepage and download
-the corresponding [T-Coffee program](http://www.tcoffee.org/Packages/Stable/Latest/) matching your operating system.
+To install `T-Coffee` please go to the [T-Coffee](https://tcoffee.readthedocs.io/en/latest/index.html) homepage and download
+the corresponding [T-Coffee program](https://tcoffee.readthedocs.io/en/latest/index.html) matching your operating system.
 
  
  
 ### Install `MUSCLE`
  
- - [__MUSCLE__](http://www.drive5.com/muscle/) : Fast and accurate multiple alignment tool of nucleic acid and protein sequences
+ - [__MUSCLE__](https://www.drive5.com/muscle/) : Fast and accurate multiple alignment tool of nucleic acid and protein sequences
  
  
 ### Install `ClustalO`
  
- 1) Download the [argtable](http://argtable.sourceforge.net/) program.
+ 1) Download the [argtable](https://argtable.sourceforge.io/) program.
  
  2) Unzip the file.
  
@@ -232,39 +251,29 @@ the corresponding [T-Coffee program](http://www.tcoffee.org/Packages/Stable/Late
  sudo make install
  ```
  
- 4) Download [ClustalO](http://www.clustal.org/omega/).
- 
- 5) Unzip the folder and run within the folder:
- 
- ```
- ./configure
- 
- make
- 
- sudo make install
- ```
+ 4) Download ClustalO via package manager (e.g. brewer, conda).
  
 ### Install `MAFFT`
  
- - [__MAFFT__](http://mafft.cbrc.jp/alignment/software/) : A tool for multiple sequence alignment and phylogeny
+ - [__MAFFT__](https://mafft.cbrc.jp/alignment/software/) : A tool for multiple sequence alignment and phylogeny
 
 
 
 
 In `orthologr` the function `multi_aln()` provides interfaces to all of these multiple alignment tools
-as well as an pairwise alignment interface to the [Biostrings](http://www.bioconductor.org/packages/release/bioc/html/Biostrings.html) package performing a [Needleman-Wunsch algorithm](http://www.sciencedirect.com/science/article/pii/0022283670900574).
+as well as an pairwise alignment interface to the [Biostrings](https://www.bioconductor.org/packages/release/bioc/html/Biostrings.html) package performing a [Needleman-Wunsch algorithm](https://www.sciencedirect.com/science/article/pii/0022283670900574).
 
 
 ## Codon Alignment Tools
 
-The codon alignment tool [Pal2Nal](http://www.bork.embl.de/pal2nal/) is already integrated in the `orthologr` package
+The codon alignment tool `Pal2Nal` is already integrated in the `orthologr` package
 and doesn't need to be installed.
 
- - [__Pal2Nal__](http://www.bork.embl.de/pal2nal/)
+ - [__Pal2Nal__](https://bio.tools/pal2nal/)
 
 You don't need to worry about downloading and installing __PAL2NAL__, it is already included in the `orthologr` package.
 The corresponding function `codon_aln()` takes a protein alignment and the corresponding coding sequences and returns
-a codon alignment by calling [__Pal2Nal__](http://www.bork.embl.de/pal2nal/) from inside of the `orthologr` package.
+a codon alignment by calling __Pal2Nal__ from inside of the `orthologr` package.
 
 ## dNdS Estimation Methods
 
@@ -276,22 +285,22 @@ The `orthologr` package includes the most common dNdS estimation methods.
 Starting with an codon alignment returned by `codon_aln()` the function `dNdS()` computes
 the the dN, dS, and dNdS values of pairs of proteins.
 
-Based on implementations provided by `gestimator`, `ape`, and [KaKs_Calculator](https://code.google.com/p/kaks-calculator/),
+Based on implementations provided by `gestimator`, `ape`, and [KaKs_Calculator](https://code.google.com/archive/p/kaks-calculator),
 the following dNdS Estimation Methods are available in `orthologr`:
 
- - [Li](http://link.springer.com/article/10.1007/BF02407308#page-1) : Li's method (1993) -> provided by the `ape package`
+ - [Li](https://link.springer.com/article/10.1007/BF02407308) : Li's method (1993) -> provided by the `ape package`
 
- - [Comeron](http://link.springer.com/article/10.1007/BF00173196) : Comeron's method (1995)
+ - [Comeron](https://link.springer.com/article/10.1007/BF00173196) : Comeron's method (1995)
 
- - [NG](http://mbe.oxfordjournals.org/content/3/5/418.short) : Nei, M. and Gojobori, T. (1986)
+ - [NG](https://academic.oup.com/mbe/content/3/5/418.short) : Nei, M. and Gojobori, T. (1986)
 
- - [LWL](http://mbe.oxfordjournals.org/content/2/2/150.short) : Li, W.H., et al. (1985)
+ - [LWL](https://academic.oup.com/mbe/article/2/2/150/1220392) : Li, W.H., et al. (1985)
 
- - [MLWL](http://mbe.oxfordjournals.org/content/21/12/2290.short) (Modified LWL), MLPB (Modified LPB): Tzeng, Y.H., et al. (2004)
+ - [MLWL](https://academic.oup.com/mbe/article/21/12/2290/1071055) (Modified LWL), MLPB (Modified LPB): Tzeng, Y.H., et al. (2004)
 
- - [YN](http://mbe.oxfordjournals.org/content/17/1/32.short) : Yang, Z. and Nielsen, R. (2000)
+ - [YN](https://academic.oup.com/mbe/article/17/1/32/975527) : Yang, Z. and Nielsen, R. (2000)
 
- - [MYN](http://www.biomedcentral.com/1471-2148/6/44/) (Modified YN): Zhang, Z., et al. (2006)
+ - [MYN](https://link.springer.com/article/10.1186/1471-2148-6-44) (Modified YN): Zhang, Z., et al. (2006)
 
 For this purpose you need to have __KaKs_Calculator__ installed on your system and executable from your default `PATH`, e,g, `/usr/local/bin/`.
 

--- a/vignettes/blast.Rmd
+++ b/vignettes/blast.Rmd
@@ -32,7 +32,7 @@ knitr::opts_chunk$set(
 The `orthologr` package provides several interface functions to perform
 BLAST searches.
 
-First, users need to make sure that they have [BLAST](ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/) installed on their machine. Please follow [these](https://github.com/HajkD/orthologr/blob/master/vignettes/Install.Rmd#install-blast) instructions to install BLAST on your manine.
+First, users need to make sure that they have [BLAST](ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/) installed on their machine. Please follow [these](https://drostlab.github.io/orthologr/articles/Install.html#install-blast) instructions to install BLAST on your manine.
 
 ## Performing BLAST Searches
 
@@ -102,7 +102,7 @@ The `blast()` function returns the BLAST arguments: `query_id`, `subject_id`, `p
 `alig_length`, `mismatches`, `gap_openings`, `q_start`, `q_end`, `s_start`, `s_end`, `evalue`, and `bit_score`.
 
 Since `blast()` stores the hit table returned by BLAST in a data.table object, you can access each column,
-using the [data.table notation](https://github.com/Rdatatable/data.table/wiki).
+using the [data.table notation](https://r-datatable.com).
 
 
 In case you need to specify the `PATH` to BLAST+ please use the `path` argument:
@@ -216,7 +216,7 @@ argument defines the default e-value that shall be chosen as best hit threshold.
 ### Using the split-apply-combine strategy for a BLAST hit table
 
 All `blast` functions implemented in `orthologr` can easily be processed using the
-[split-apply-combine strategy](http://www.jstatsoft.org/v40/i01/paper) to detect 
+[split-apply-combine strategy](https://www.jstatsoft.org/htaccess.php?volume=40&type=i&issue=01&filename=paper) to detect 
 for example `one-to-one`, `one-to-many`, and `many-to-many` gene homology relationships.
 
 Here a simple example:
@@ -509,7 +509,7 @@ Now users can perform a global alignment between the CDS sequences of `AT1G01070
 and the three subject genes as follows:
 
 ```{r,eval=FALSE}
-library(Biostrings)
+library(Biostrings); library(pwalign)
 # perform 3 global alignments between:  AT1G01070.1 and 918864|PACid:16052578, 
 # 919693|PACid:16048878, 919961|PACid:16062329
 sapply(Aly.cds[ unlist(dplyr::select(dplyr::filter(hit_tbl, query_id == "AT1G01070.1"), subject_id)), seqs ], pairwiseAlignment, 
@@ -758,18 +758,10 @@ LDCYRSLLLRKSDEESSFSDSPVLLSIKVLIGVLSANAAFIISFAIATKGLLNEVSRRREIMLGIFISSYFKIFLLAMLV
 VDILLLTSNSMALKVMTESTMTRCIAVCLIAHLIRFLVGQIFEPTIFLIQIGSLLQYMSYFFRIV*
 ```
 
-## Perform BLAST Searches between Genomes or Proteomes
+## Advanced BLAST+ analyses
 
-For large-scale applications of `orthologr`, users may wish to perform BLAST+
-searches between entire genomes. For very large-scale BLAST+ searches
-between genomes we recommend the user to use the [metablastr](https://github.com/HajkD/metablastr) package
+For large-scale applications of BLAST+ analysis within R, we recommend users to see the [metablastr](https://github.com/drostlab/metablastr) package
 which aims to provide an easy-to-use BLAST search framework
 for massive genome comparisons.
-
-For pairwise genome comparisons however, users can use the following
-functions to BLAST one genome against another.
-
-### Genome and Proteome Retrieval
-
 
 

--- a/vignettes/dNdS_estimation.Rmd
+++ b/vignettes/dNdS_estimation.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 The dN/dS ratio quantifies the mode and strength of selection acting on a pair of orthologous genes.
 This selection pressure can be quantified by comparing synonymous substitution rates (dS) that are assumed to be neutral
 with nonsynonymous substitution rates (dN), which are exposed to selection as they 
-change the amino acid composition of a protein ([Mugal et al., 2013](http://mbe.oxfordjournals.org/content/31/1/212)).
+change the amino acid composition of a protein ([Mugal et al., 2013](https://academic.oup.com/mbe/article/31/1/212/1049986)).
 
 The `orthologr` package provides a function named `dNdS()` to perform dNdS estimation on pairs of orthologous genes.
 The `dNdS()` function takes the CDS files of two organisms of interest (`query_file` and `subject_file`) 
@@ -60,13 +60,13 @@ The following pipeline resembles an example dNdS estimation procedure:
  
  3) Codon Alignment: e.g. pal2nal program
  
- 4) dNdS estimation: e.g. [Yang, Z. and Nielsen, R. (2000)](http://mbe.oxfordjournals.org/content/17/1/32.short) (YN)
+ 4) dNdS estimation: e.g. [Yang, Z. and Nielsen, R. (2000)](https://academic.oup.com/mbe/article/17/1/32/975527) (YN)
 
 
 __Note:__ it is assumed that when using `dNdS()` all corresponding multiple sequence alignment programs you
 want to use are already installed on your machine and are executable via either
 the default execution PATH or you specifically define the location of the executable program
-via the `aa_aln_path` or `blast_path` argument that can be passed to `dNdS()`. See the [Sequence Alignments vignette](https://github.com/HajkD/orthologr/blob/master/vignettes/sequence_alignments.Rmd)
+via the `aa_aln_path` or `blast_path` argument that can be passed to `dNdS()`. See the [Sequence Alignments vignette](https://drostlab.github.io/orthologr/articles/sequence_alignments.html)
 for details.
 
 The following example shall illustrate a dNdS estimation process.

--- a/vignettes/divergence_stratigraphy.Rmd
+++ b/vignettes/divergence_stratigraphy.Rmd
@@ -18,17 +18,17 @@ knitr::opts_chunk$set(
 
 The `orthologr` package allows users to perform __Divergence Stratigraphy__ for any query and subject organisms of interest.
 
-__Divergence Stratigraphy__ is the process of quantifying the selection pressure (in terms of protein evolutionary rate) acting on orthologous genes between closely related species. The resulting sequence divergence map (short divergence map), stores the divergence stratum in the first column and the `query_id` of inferred orthologous genes in the second column ( Quint et al., 2012 _Nature_; [Drost et al., 2015 _Mol. Biol. Evol._](http://mbe.oxfordjournals.org/content/32/5/1221.full); [Drost et al., 2016 _Mol. Biol. Evol._](http://mbe.oxfordjournals.org/content/early/2016/02/23/molbev.msw039.abstract); [Introduction to myTAI](https://github.com/HajkD/myTAI) ). [Here](https://github.com/HajkD/myTAI/issues/5) you can also find a short example and discussion about the usefulness of `Divergence Strata`.
+__Divergence Stratigraphy__ is the process of quantifying the selection pressure (in terms of protein evolutionary rate) acting on orthologous genes between closely related species. The resulting sequence divergence map (short divergence map), stores the divergence stratum in the first column and the `query_id` of inferred orthologous genes in the second column ( Quint et al., 2012 _Nature_; [Drost et al., 2015 _Mol. Biol. Evol._](https://academic.oup.com/mbe/article/32/5/1221/1125964); [Drost et al., 2016 _Mol. Biol. Evol._](https://academic.oup.com/mbe/article/33/5/1158/2580081); [Introduction to myTAI](https://drostlab.github.io/myTAI) ). [Here](https://github.com/drostlab/myTAI/issues/5) you can also find a short example and discussion about the usefulness of `Divergence Strata`.
 
-The following Algorithm implemented in `divergence_stratigraphy()` defines __Divergence Stratigraphy__ as method (see [Drost et al., 2015](http://mbe.oxfordjournals.org/content/32/5/1221.full)):
+The following Algorithm implemented in `divergence_stratigraphy()` defines __Divergence Stratigraphy__ as method (see [Drost et al., 2015](https://academic.oup.com/mbe/article/32/5/1221/1125964)):
 
 1) Orthology Inference using BLAST best reciprocal hit ("RBH") based on blastp
 
-2) Pairwise global amino acid alignments of orthologous genes using the [Needleman-Wunsch algorithm](http://www.sciencedirect.com/science/article/pii/0022283670900574)
+2) Pairwise global amino acid alignments of orthologous genes using the [Needleman-Wunsch algorithm](https://www.sciencedirect.com/science/article/pii/0022283670900574)
 
-3) Codon alignments of orthologous genes using [PAL2NAL](http://www.bork.embl.de/pal2nal/)
+3) Codon alignments of orthologous genes using [PAL2NAL](https://bio.tools/pal2nal)
 
-4) dNdS estimation using [Comeron's method (1995)](http://link.springer.com/article/10.1007/BF00173196)
+4) dNdS estimation using [Comeron's method (1995)](https://link.springer.com/article/10.1007/BF00173196)
 
 5) Categorize estimated dNdS values into `divergence strata` (= deciles of all dNdS values)
 
@@ -37,10 +37,10 @@ The following Algorithm implemented in `divergence_stratigraphy()` defines __Div
 In other words, imagine having 10000 orthologous genes and their corresponding Ka/Ks values after performing a pairwise genome comparison using the `dNdS()` function. Now, these 10000 Ka/Ks values follow a distribution between 0 and +Inf, where Ka/Ks < 1 reflects purifying selection, Ka/Ks = 1 reflects neutral evolution, and Ka/Ks > 1 reflects positive selection (in reality usually the largest Ka/Ks values I have seen are e.g. 100). Next, you bin these 10000 Ka/Ks values according to their 10% quantile (= decile), meaning that the lowest 10% of Ka/Ks values are in decile one (= Divergence Stratum 1), the lowest Ka/Ks values between the 11%-20% quantile are in decile two (= Divergence Stratum 2), ..., and the largest Ka/Ks values between the 91-100% quantile are in decile 10 (= Divergence Stratum 10) (This is what the `divergence_map()` function does). This way, each Divergence Stratum has (almost) the same number of genes.
 
 
-In `orthologr` the [Needleman-Wunsch algorithm](http://www.sciencedirect.com/science/article/pii/0022283670900574), [PAL2NAL](http://www.bork.embl.de/pal2nal/) and [Comeron's method (1995)](http://link.springer.com/article/10.1007/BF00173196) 
+In `orthologr` the [Needleman-Wunsch algorithm](https://www.sciencedirect.com/science/article/pii/0022283670900574), [PAL2NAL](https://bio.tools/pal2nal/) and [Comeron's method (1995)](https://link.springer.com/article/10.1007/BF00173196) 
 are already included in the `orthologr` package and do not have to be installed separately. Nevertheless, users need to make sure __they have BLAST installed on their machine before using the `divergence_stratigraphy()`function__.  
 
-__Note__: The following examples assume that the __BLAST__ program is installed and stored in the default execution path `usr/local/bin`. In case users do not have __BLAST__ installed yet or the following command in R produces a different output, please consult the [Installation Vignette](https://github.com/HajkD/orthologr/blob/master/vignettes/Install.Rmd#orthology-inference-tools) to corretly set up the __BLAST__ program to perform __Divergence Stratigraphy__.  
+__Note__: The following examples assume that the __BLAST__ program is installed and stored in the default execution path `usr/local/bin`. In case users do not have __BLAST__ installed yet or the following command in R produces a different output, please consult the [Installation Vignette](https://drostlab.github.io/orthologr/articles/Install.html) to correctly set up the __BLAST__ program to perform __Divergence Stratigraphy__.  
 
 ```{r,eval=FALSE}
 system("blastp -version")
@@ -55,7 +55,7 @@ Package: blast 2.2.30, build Oct 27 2014 17:10:51
 
 ## Divergence Map Computations
 
-In [Drost et al., 2015 _Mol. Biol. Evol._](http://mbe.oxfordjournals.org/content/32/5/1221.full) we define a `Divergence Map` as table storing the degree of selection pressure (= `divergence strata`) for each protein coding gene of a given query organism. In this case selection pressure was quantified by dNdS estimation (ratio of synonymous versus non-synonymous `codon -> amino acid` sequence substitution rates).
+In [Drost et al., 2015 _Mol. Biol. Evol._](https://academic.oup.com/mbe/article/32/5/1221/1125964) we define a `Divergence Map` as table storing the degree of selection pressure (= `divergence strata`) for each protein coding gene of a given query organism. In this case selection pressure was quantified by dNdS estimation (ratio of synonymous versus non-synonymous `codon -> amino acid` sequence substitution rates).
 The resulting dNdS values for all protein coding genes of the query organism are then categorized into deciles (10%-quantiles) allowing users to compare the results obtained from `Phylostratigraphy` with results obtained form `Divergence Stratigraphy`. 
 
 To perform __Divergence Stratigraphy__ using `orthologr` users need to retrieve the following input files:
@@ -99,17 +99,19 @@ When the download is finished you need to unzip the files.
 
 #### Option 2:
 
-We implemented the [biomartr](https://github.com/HajkD/biomartr) package to automate the process of performing biological data retrieval. The [Sequence Retrieval Vignette](https://github.com/HajkD/biomartr/blob/master/vignettes/Sequence_Retrieval.Rmd) stored in `biomartr` provides detailed use cases for the automation of biological sequence retrieval.
+We implemented the [biomartr](https://github.com/ropensci/biomartr) package to automate the process of performing biological data retrieval. The [Sequence Retrieval Vignette](https://docs.ropensci.org/biomartr/articles/Sequence_Retrieval.html) stored in `biomartr` provides detailed use cases for the automation of biological sequence retrieval.
 
-__Note__: Users need to make sure they have [biomartr](https://github.com/HajkD/biomartr#fast-installation-guide) installed before running any `biomartr` functions.
+__Note__: Users need to make sure they have [biomartr](https://docs.ropensci.org/biomartr/index.html#installation) installed before running any `biomartr` functions.
 
 ### Computation Time
 
-__Please note that__ performing __Divergence Stratigraphy__ with two large genomes can take
+__Please note that__ performing __Divergence Stratigraphy__ with two large genomes using BLAST+ can take
 (even on a multicore machine) some time -> __up to several hours__.
 On a 4 core machine with 3.4 GHz i7 processors the computation time of generating a divergence map between _A. thaliana_ and _A. lyrata_ was __2.5-3 hours__.
 
 The `comp_cores` argument implemented in the `divergence_stratigraphy()` function allows users to specify the number of cores they would like to use on their machine. The default value is `comp_cores = 1` which might take __10-12h__ to execute. So users need to make sure that they use all cores available on their machine to speed up the computation time.
+
+(Note, the wall clock time is now reduced with the `diamond`.)
 
 ## Running `divergence_stratigraphy()`
 
@@ -117,7 +119,7 @@ As mentioned earlier the `divergence_stratigraphy()` function is the main functi
 
 In `divergence_stratigraphy()` the `query_file` and `subject_file` arguments take an
 character string storing the path to the corresponding __fasta__ files containing the CDS
-sequences of these organisms. Here the previously downloaded CDS sequence files of _A. thaliana_ (= `query_file`) and _A. lyrata_ (= `subject_file`) need to be specified. The `eval` is set to `1E-5` (default ; see Quint et al., 2012 _Nature_) and `BLAST best reciprocal hit` is used for orthology inference (see [Drost et al., 2015](http://mbe.oxfordjournals.org/content/32/5/1221.full)). In case ``orthologr` is running on a multicore machine, users can set the `comp_cores` argument to any number of cores
+sequences of these organisms. Here the previously downloaded CDS sequence files of _A. thaliana_ (= `query_file`) and _A. lyrata_ (= `subject_file`) need to be specified. The `eval` is set to `1E-5` (default ; see Quint et al., 2012 _Nature_) and `BLAST best reciprocal hit` is used for orthology inference (see [Drost et al., 2015](https://academic.oup.com/mbe/article/32/5/1221/1125964)). In case ``orthologr` is running on a multicore machine, users can set the `comp_cores` argument to any number of cores
 supported by their machine. The `clean_folders` argument indicates whether or not the internal folder structure should be deleted (cleaned) after processing is finished. In this case all output files generated by `divergence_stratigraphy` (stored in `tempdir()`) will be removed after the `Divergence Map` was returned. The `quiet` argument indicates whether or not a successful interface call should be printed out to the console (`quiet = FALSE`) or not (`quiet = TRUE`).
 
 
@@ -308,7 +310,7 @@ The corresponding output now stores `dNdS` values instead of `DS` values in the 
 
 #### Example: `subject.id`
 
-Although the `Divergence Map` [standard](https://github.com/HajkD/myTAI/blob/master/vignettes/Introduction.Rmd#getting-started) is specified as storing `DS` values in the first column and `GeneIDs` in the second column, in some cases it is important to store the GeneIDs of orthologous genes in the `subject` organism. The `subject.id` argument implemented in `divergence_stratigraphy()` allows users to retrieve the GeneIDs of the orthologous genes of the `subject` organism. For this purpose users need to specify `subject.id = TRUE`.
+Although the `Divergence Map` [standard](https://drostlab.github.io/myTAI) is specified as storing `DS` values in the first column and `GeneIDs` in the second column, in some cases it is important to store the GeneIDs of orthologous genes in the `subject` organism. The `subject.id` argument implemented in `divergence_stratigraphy()` allows users to retrieve the GeneIDs of the orthologous genes of the `subject` organism. For this purpose users need to specify `subject.id = TRUE`.
 
 
 ```{r,eval=FALSE}
@@ -417,7 +419,7 @@ The default value for `dnds.threshold` in `divergence_stratigraphy()` is `dnds.t
 
 #### Example: `ortho_detection`
 
-According to [Drost et al., 2015 _Mol. Biol. Evol._](http://mbe.oxfordjournals.org/content/32/5/1221.full) the __Divergence Stratigraphy__ algorithm performs __BLAST__ best reciprocal hit (RBH) as orthology inference method. Despite this convention, the `ortho_detection` argument allows users to perform orthology inference within the __Divergence Stratigraphy__ algorithm that is based on any orthology inference method implemented in `orthologr` (see `?orthologs` or [Orthology Inference Vignette](https://github.com/HajkD/orthologr/blob/master/vignettes/orthology_inference.Rmd) for details). For example in Quint et al., 2012 _Nature_ instead of using __BLAST__ best reciprocal hit, the method __BLAST__ best hit (BH) was used to perform orthology inference within the __Divergence Stratigraphy__ algorithm.
+According to [Drost et al., 2015 _Mol. Biol. Evol._](https://academic.oup.com/mbe/article/32/5/1221/1125964) the __Divergence Stratigraphy__ algorithm performs __BLAST__ best reciprocal hit (RBH) as orthology inference method. Despite this convention, the `ortho_detection` argument allows users to perform orthology inference within the __Divergence Stratigraphy__ algorithm that is based on any orthology inference method implemented in `orthologr` (see `?orthologs` or [Orthology Inference Vignette](https://drostlab.github.io/orthologr/articles/orthology_inference.html) for details). For example in Quint et al., 2012 _Nature_ instead of using __BLAST__ best reciprocal hit, the method __BLAST__ best hit (BH) was used to perform orthology inference within the __Divergence Stratigraphy__ algorithm.
 
 
 ```{r,eval=FALSE}
@@ -462,13 +464,13 @@ According to [Drost et al., 2015 _Mol. Biol. Evol._](http://mbe.oxfordjournals.o
 
 ## Skip `Divergence Stratigraphy` and Download Already Published `Divergence Maps`
 
-Users can find a detailed list of [published Phylostratigraphic Maps and Divergence Maps](https://github.com/HajkD/published_phylomaps) by following the link. This way
+Users can find a detailed list of [published Phylostratigraphic Maps and Divergence Maps](https://github.com/drostlab/published_phylomaps) by following the link. This way
 the computation time of 3-4 h on a local machine for 2 genome comparisions can be skipped.
 
 
 ## Combine a Divergence Map with Gene Expression Data
 
-`Divergence Maps` can be used for a wide range of analyses. One example is to combine `Divergence Maps` with gene expression data to capture evolutionary signals in developmental transcriptomes (= `Phylotranscriptomics`; see [Drost et al., 2015 _Mol. Biol. Evol._](http://mbe.oxfordjournals.org/content/32/5/1221.full)). Performing phylotranscriptomic analyses based on an existing `Divergence Map` can easily be done by using the `myTAI` package. You can consult the [Introduction to the myTAI package Vignette](https://github.com/HajkD/myTAI/blob/master/vignettes/Introduction.Rmd)
+`Divergence Maps` can be used for a wide range of analyses. One example is to combine `Divergence Maps` with gene expression data to capture evolutionary signals in developmental transcriptomes (= `Phylotranscriptomics`; see [Drost et al., 2015 _Mol. Biol. Evol._](https://academic.oup.com/mbe/article/32/5/1221/1125964)). Performing phylotranscriptomic analyses based on an existing `Divergence Map` can easily be done by using the `myTAI` package. You can consult the [Introduction to the myTAI package Vignette](https://drostlab.github.io/myTAI/articles/other-strata.html)
 for more details.
 
 

--- a/vignettes/orthology_inference.Rmd
+++ b/vignettes/orthology_inference.Rmd
@@ -385,10 +385,4 @@ subsequent analyses, you can specify the `clean_folders = FALSE` argument. The c
 BLAST hit table can then be found in `file.path(tempdir(),"_blast_db")`.
 
 A detailed overview of further analyses that can be done with the corresponding BLAST output
-can be found in the [BLAST vignette](https://github.com/HajkD/orthologr/blob/master/vignettes/blast.Rmd).
-
-
-### Examples: Orthogroup based methods
-
-
-
+can be found in the [BLAST vignette](https://drostlab.github.io/orthologr/articles/blast.html).

--- a/vignettes/sequence_alignments.Rmd
+++ b/vignettes/sequence_alignments.Rmd
@@ -24,17 +24,17 @@ The above mentioned functions provide interfaces to the following alignment prog
 
 ### The `multi_aln()` function
 
-* [__ClustalW__](http://www.clustal.org/clustal2/) : Advanced multiple alignment tool of nucleic acid and protein sequences
+* __ClustalW__ : Advanced multiple alignment tool of nucleic acid and protein sequences
  
-* [__T_Coffee__](http://www.tcoffee.org/Projects/tcoffee/) : A collection of tools for processing multiple sequence alignments
+* [__T_Coffee__](https://tcoffee.readthedocs.io/en/latest/index.html) : A collection of tools for processing multiple sequence alignments
  of nucleic acids and proteins as well as their 3D structure
  
-* [__MUSCLE__](http://www.drive5.com/muscle/) : Fast and accurate multiple alignment tool of nucleic acid and protein sequences
+* [__MUSCLE__](https://www.drive5.com/muscle/) : Fast and accurate multiple alignment tool of nucleic acid and protein sequences
  
-* [__ClustalO__](http://www.clustal.org/omega/) : Fast and scalable multiple alignment tool for nucleic acid and protein sequences that is also
+* __ClustalO__ : Fast and scalable multiple alignment tool for nucleic acid and protein sequences that is also
  capable of performing HMM alignments
  
-* [__MAFFT__](http://mafft.cbrc.jp/alignment/software/) : A tool for multiple sequence alignment and phylogeny
+* [__MAFFT__](https://mafft.cbrc.jp/alignment/software/) : A tool for multiple sequence alignment and phylogeny
 
 The easiest way to use the `multi_aln()` function is to store the corresponding multiple sequence alignment tools in the default execution `PATH` of you system (e.g. `/usr/local/bin` on UNIX machines).
 
@@ -233,7 +233,7 @@ In case everything is installed appropriately, you should see:
 ```
 ------------------------------------------------------------------------------
   MAFFT v7.187 (2014/10/02)
-  http://mafft.cbrc.jp/alignment/software/
+  https://mafft.cbrc.jp/alignment/software/
   MBE 30:772-780 (2013), NAR 30:3059-3066 (2002)
 ------------------------------------------------------------------------------
 High speed:


### PR DESCRIPTION
Updated documentation and dependency. This allowed `devtools::check_win_devel()` to work. Hopefully then, `orthologr` can now be run again on windows.

- Created unit tests for `diamond` and `blast` functions.

- Moved `metablastr` from `Imports` to `Suggests` in `DESCRIPTION`, and updated the `Remotes`. This clarifies that `metablastr` is an optional rather than required dependency. 
- Added a runtime check in `orthologs_lnc.R` to provide a clear error message and installation instructions if `metablastr` is not installed when required.

- Updated a large number of URLs throughout the R scripts and documentation to use secure `https` links and point to current resources (e.g., NCBI, Ensembl, Clustal, MAFFT, T-Coffee, and others). 
- Updated references and links in `NEWS.md` to point to the correct GitHub repositories and more stable URLs (e.g., using `doi.org` for articles, updating repository links to `drostlab`). 

- Updated the `Date` field in `DESCRIPTION` to a future date (`2026-06-02`), and made minor changes to `Config/roxygen2/version` and other metadata fields. 